### PR TITLE
Remove HTML wrappers from SSL redirect script

### DIFF
--- a/wp-content/plugins/wp-letsencrypt-ssl/admin/js/jsredirect.js
+++ b/wp-content/plugins/wp-letsencrypt-ssl/admin/js/jsredirect.js
@@ -1,5 +1,3 @@
-<script>
 if (document.location.protocol != "https:") {
     document.location = document.URL.replace(/^http:/i, "https:");
 }
-</script>


### PR DESCRIPTION
## Summary
- convert jsredirect.js to plain JavaScript by removing `<script>` tags

## Testing
- `node --check wp-content/plugins/wp-letsencrypt-ssl/admin/js/jsredirect.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e08b4b9c48329841864ac231f1061