### PR TITLE
Show profile info in dashboard menu

### DIFF
--- a/wp-content/themes/storefront/header.php
+++ b/wp-content/themes/storefront/header.php
@@ -45,10 +45,52 @@
 		 * @hooked storefront_header_cart                      - 60
 		 * @hooked storefront_primary_navigation_wrapper_close - 68
 		 */
-		do_action( 'storefront_header' );
-		?>
+                do_action( 'storefront_header' );
+                ?>
 
-	</header><!-- #masthead -->
+               <?php if ( is_page( 'dashboard' ) ) : ?>
+               <div class="sff-app-menu">
+                       <button id="sff-menu-toggle" class="sff-menu-toggle" aria-expanded="false" aria-controls="sff-menu">
+                               <span class="bar"></span>
+                               <span class="bar"></span>
+                               <span class="bar"></span>
+                       </button>
+                       <nav id="sff-menu" class="sff-menu" aria-labelledby="sff-menu-toggle">
+                               <ul>
+                                       <?php if ( is_user_logged_in() ) : ?>
+                                               <li class="sff-profile-item">
+                                                       <button id="sff-profile-toggle" class="sff-profile-toggle"><?php esc_html_e( 'Profile', 'storefront' ); ?></button>
+                                                       <div id="sff-profile-content" class="sff-profile-content">
+                                                               <?php echo do_shortcode( '[sff_client_profile]' ); ?>
+                                                       </div>
+                                               </li>
+                                       <?php else : ?>
+                                               <li><a href="<?php echo esc_url( wp_login_url() ); ?>"><?php esc_html_e( 'Log in', 'storefront' ); ?></a></li>
+                                       <?php endif; ?>
+                               </ul>
+                       </nav>
+               </div>
+               <style>
+                       #masthead{position:relative;}
+                       .sff-app-menu{position:absolute;top:1rem;right:1rem;}
+                       .sff-menu-toggle{background:none;border:0;cursor:pointer;display:flex;flex-direction:column;justify-content:space-between;width:24px;height:18px;padding:0;}
+                       .sff-menu-toggle .bar{display:block;width:100%;height:3px;background:#333;}
+                       .sff-menu{display:none;position:absolute;top:100%;right:0;background:#fff;border:1px solid #ccc;border-radius:4px;padding:.5rem 1rem;z-index:999;}
+                       .sff-menu.open{display:block;}
+                       .sff-menu ul{list-style:none;margin:0;padding:0;}
+                       .sff-menu li{margin:0;}
+                       .sff-menu a{display:block;padding:.5rem 0;color:#333;text-decoration:none;}
+                       .sff-profile-content{display:none;margin-top:.5rem;max-height:300px;overflow:auto;}
+                       .sff-profile-content.open{display:block;}
+                       .sff-profile-toggle{background:none;border:0;cursor:pointer;color:#333;padding:.5rem 0;width:100%;text-align:left;}
+                       .sff-profile-content .sff-profile-card{max-width:260px;margin:0;}
+               </style>
+               <script>
+               document.addEventListener('DOMContentLoaded',function(){var t=document.getElementById('sff-menu-toggle');var m=document.getElementById('sff-menu');var p=document.getElementById('sff-profile-toggle');var c=document.getElementById('sff-profile-content');if(t&&m){t.addEventListener('click',function(){var e=t.getAttribute('aria-expanded')==='true';t.setAttribute('aria-expanded',(!e).toString());m.classList.toggle('open');});}if(p&&c){p.addEventListener('click',function(){c.classList.toggle('open');});}});
+               </script>
+               <?php endif; ?>
+
+        </header><!-- #masthead -->
 
 	<?php
 	/**


### PR DESCRIPTION
## Summary
- render hamburger menu only on dashboard view
- add Profile toggle that reveals intake-form data via existing shortcode

## Testing
- `php -l wp-content/themes/storefront/header.php`


------
https://chatgpt.com/codex/tasks/task_e_689e21559e6c83299e2ef76a7b466dff