### PR TITLE
Add dynamic profile modal to dashboard

### DIFF
--- a/wp-content/plugins/simplified-food-fitness/assets/css/sff-styles.css
+++ b/wp-content/plugins/simplified-food-fitness/assets/css/sff-styles.css
@@ -210,3 +210,91 @@
     color: #1f1f1f;
 }
 
+/* Dashboard Hamburger Menu */
+.sff-hamburger {
+    background: none;
+    border: none;
+    font-size: 24px;
+    cursor: pointer;
+    color: #023441;
+}
+
+.sff-menu-items {
+    position: absolute;
+    top: 60px;
+    right: 0;
+    background: #ffffff;
+    border: 1px solid #e0e0e0;
+    border-radius: 8px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+    display: none;
+    flex-direction: column;
+    min-width: 150px;
+    z-index: 1000;
+}
+
+.sff-menu-items a {
+    padding: 10px 15px;
+    color: #1f1f1f;
+    text-decoration: none;
+}
+
+.sff-menu-items a:hover {
+    background: #f0f0f0;
+}
+
+/* Profile Modal */
+.sff-modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.5);
+    display: none;
+    align-items: center;
+    justify-content: center;
+    z-index: 10000;
+}
+
+.sff-modal-content {
+    background: #ffffff;
+    border-radius: 12px;
+    max-width: 600px;
+    width: 90%;
+    max-height: 90%;
+    overflow: auto;
+    position: relative;
+    padding: 20px;
+}
+
+.sff-modal-close {
+    position: absolute;
+    top: 10px;
+    right: 15px;
+    background: none;
+    border: none;
+    font-size: 24px;
+    cursor: pointer;
+}
+
+@media (max-width: 768px) {
+    .sff-menu-items {
+        top: 50px;
+        right: 0;
+    }
+
+    .sff-modal-content {
+        width: 95%;
+    }
+
+    .sff-profile-field {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .sff-profile-field label {
+        margin-bottom: 4px;
+    }
+}
+

--- a/wp-content/plugins/simplified-food-fitness/assets/js/sff-scripts.js
+++ b/wp-content/plugins/simplified-food-fitness/assets/js/sff-scripts.js
@@ -286,6 +286,39 @@ jQuery(document).ready(function($) {
       }
     });
   });
+
+  // Hamburger menu toggle
+  $('#sff-menu-toggle').on('click', function () {
+    $('#sff-menu').toggle();
+  });
+
+  // Load profile via AJAX when menu item is clicked
+  $('#sff-profile-link').on('click', function (e) {
+    e.preventDefault();
+    $('#sff-menu').hide();
+    $('#sff-profile-modal').fadeIn();
+    $('#sff-profile-content').html('<p>Loading...</p>');
+    $.post(
+      sff_ajax_obj.ajax_url,
+      { action: 'sff_load_profile', security: sff_ajax_obj.nonce },
+      function (response) {
+        $('#sff-profile-content').html(response);
+      }
+    );
+  });
+
+  function closeProfileModal() {
+    $('#sff-profile-modal').fadeOut();
+    $('#sff-profile-content').empty();
+  }
+
+  $('.sff-modal-close').on('click', closeProfileModal);
+
+  $('#sff-profile-modal').on('click', function (e) {
+    if (e.target.id === 'sff-profile-modal') {
+      closeProfileModal();
+    }
+  });
 });
 
 

--- a/wp-content/plugins/simplified-food-fitness/includes/ajax.php
+++ b/wp-content/plugins/simplified-food-fitness/includes/ajax.php
@@ -689,3 +689,20 @@ function sff_convert_to_client() {
         'post_id' => $lead_id
     ]);
 }
+
+// Load client profile via AJAX
+add_action('wp_ajax_sff_load_profile', 'sff_load_profile');
+add_action('wp_ajax_nopriv_sff_load_profile', 'sff_load_profile');
+
+function sff_load_profile() {
+    if (!isset($_POST['security']) || !wp_verify_nonce($_POST['security'], 'sff_scan_nonce')) {
+        wp_die('Security check failed', 403);
+    }
+
+    if (!is_user_logged_in()) {
+        wp_die('Unauthorized', 403);
+    }
+
+    echo do_shortcode('[sff_client_profile]');
+    wp_die();
+}

--- a/wp-content/plugins/simplified-food-fitness/includes/shortcodes.php
+++ b/wp-content/plugins/simplified-food-fitness/includes/shortcodes.php
@@ -154,8 +154,6 @@ function sff_frontend_dashboard_pretty() {
     ob_start(); ?>
     
     <div class="dashboard-container" style="max-width:1200px; margin:auto; padding:20px; font-family:'Segoe UI', Arial, sans-serif;">
-        <?php echo do_shortcode('[sff_client_profile]'); ?>
-        
         <!-- Header Section -->
         <div style="display:flex; align-items:center; justify-content:space-between; gap:15px; flex-wrap:wrap; text-align:left; margin-bottom:30px;">
             <!-- Left Logo -->
@@ -172,6 +170,14 @@ function sff_frontend_dashboard_pretty() {
                     <p style="font-size:16px; color:#777; margin:0;">
                         <?php echo esc_html($day_type); ?>
                     </p>
+                </div>
+            </div>
+
+            <!-- Hamburger Menu -->
+            <div class="sff-hamburger-wrapper" style="position:relative;">
+                <button id="sff-menu-toggle" class="sff-hamburger">&#9776;</button>
+                <div id="sff-menu" class="sff-menu-items">
+                    <a href="#" id="sff-profile-link">Profile</a>
                 </div>
             </div>
         </div>
@@ -252,6 +258,15 @@ function sff_frontend_dashboard_pretty() {
             </div>
         </div>
     </div>
+
+    <!-- Profile Modal -->
+    <div id="sff-profile-modal" class="sff-modal" style="display:none;">
+        <div class="sff-modal-content">
+            <button class="sff-modal-close" aria-label="Close">&times;</button>
+            <div id="sff-profile-content"></div>
+        </div>
+    </div>
+
     <?php
     return ob_get_clean();
 }


### PR DESCRIPTION
## Summary
- Add hamburger menu with Profile entry on dashboard
- Load client profile shortcode on demand in modal
- Style and script modal/menu for responsive mobile use

## Testing
- `php -l wp-content/plugins/simplified-food-fitness/includes/shortcodes.php`
- `php -l wp-content/plugins/simplified-food-fitness/includes/ajax.php`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e2bf87b94832986296b4995a41350