### PR TITLE
Add off-canvas dashboard menu with hamburger toggle

### DIFF
--- a/wp-content/plugins/simplified-food-fitness/assets/css/sff-styles.css
+++ b/wp-content/plugins/simplified-food-fitness/assets/css/sff-styles.css
@@ -210,3 +210,50 @@
     color: #1f1f1f;
 }
 
+/* Dashboard Hamburger Menu */
+.sff-hamburger {
+    cursor: pointer;
+    width: 30px;
+    height: 22px;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+}
+
+.sff-hamburger span {
+    display: block;
+    height: 3px;
+    background: #333;
+    border-radius: 2px;
+}
+
+.sff-offcanvas-menu {
+    position: fixed;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 250px;
+    background: #fff;
+    box-shadow: 2px 0 8px rgba(0, 0, 0, 0.1);
+    transform: translateX(-100%);
+    transition: transform 0.3s ease;
+    z-index: 1000;
+    padding: 20px;
+}
+
+.sff-offcanvas-menu.sff-menu-open {
+    transform: translateX(0);
+}
+
+@media (min-width: 768px) {
+    .sff-offcanvas-menu {
+        width: 300px;
+    }
+}
+
+@media (max-width: 767px) {
+    .sff-offcanvas-menu {
+        width: 80%;
+    }
+}
+

--- a/wp-content/plugins/simplified-food-fitness/assets/js/dashboard-menu.js
+++ b/wp-content/plugins/simplified-food-fitness/assets/js/dashboard-menu.js
@@ -1,0 +1,9 @@
+document.addEventListener('DOMContentLoaded', function() {
+    var toggle = document.getElementById('sff-menu-toggle');
+    var menu = document.getElementById('sff-offcanvas-menu');
+    if (toggle && menu) {
+        toggle.addEventListener('click', function() {
+            menu.classList.toggle('sff-menu-open');
+        });
+    }
+});

--- a/wp-content/plugins/simplified-food-fitness/includes/enqueue.php
+++ b/wp-content/plugins/simplified-food-fitness/includes/enqueue.php
@@ -16,6 +16,14 @@ function sff_enqueue_assets() {
         true
     );
 
+    wp_enqueue_script(
+        'sff-dashboard-menu',
+        SFF_PLUGIN_URL . 'assets/js/dashboard-menu.js',
+        [],
+        '1.0.0',
+        true
+    );
+
     // ✅ Localize AJAX object
     wp_localize_script('sff-scripts', 'sff_ajax_obj', [
         'ajax_url' => admin_url('admin-ajax.php'),

--- a/wp-content/plugins/simplified-food-fitness/includes/shortcodes.php
+++ b/wp-content/plugins/simplified-food-fitness/includes/shortcodes.php
@@ -154,10 +154,20 @@ function sff_frontend_dashboard_pretty() {
     ob_start(); ?>
     
     <div class="dashboard-container" style="max-width:1200px; margin:auto; padding:20px; font-family:'Segoe UI', Arial, sans-serif;">
+        <!-- Off-canvas Menu Container -->
+        <div id="sff-offcanvas-menu" class="sff-offcanvas-menu"></div>
+
         <?php echo do_shortcode('[sff_client_profile]'); ?>
-        
+
         <!-- Header Section -->
-        <div style="display:flex; align-items:center; justify-content:space-between; gap:15px; flex-wrap:wrap; text-align:left; margin-bottom:30px;">
+        <div style="display:flex; align-items:center; gap:15px; flex-wrap:wrap; text-align:left; margin-bottom:30px;">
+            <!-- Hamburger Icon -->
+            <div id="sff-menu-toggle" class="sff-hamburger" style="flex-shrink:0;">
+                <span></span>
+                <span></span>
+                <span></span>
+            </div>
+
             <!-- Left Logo -->
             <div style="flex-shrink:0;">
                 <img src="<?php echo esc_url($logo_url); ?>" alt="Logo" style="height:70px; width:auto; max-width:200px;">


### PR DESCRIPTION
## Summary
- Render hamburger trigger and hidden off-canvas menu in frontend dashboard
- Enqueue new dashboard-menu.js and styles for sliding panel
- Style hamburger icon and responsive slide-in menu

## Testing
- `php -l wp-content/plugins/simplified-food-fitness/includes/shortcodes.php`
- `php -l wp-content/plugins/simplified-food-fitness/includes/enqueue.php`


------
https://chatgpt.com/codex/tasks/task_e_689e2bf66ae4832987a71f5239c175e3