### PR TITLE
Add dedicated profile page and clean dashboard link

### DIFF
--- a/wp-content/plugins/simplified-food-fitness/assets/css/sff-styles.css
+++ b/wp-content/plugins/simplified-food-fitness/assets/css/sff-styles.css
@@ -190,20 +190,34 @@
     color: #1D2939;
 }
 
+.sff-profile-card h2::before {
+    content: "\1F464"; /* 👤 */
+    margin-right: 6px;
+}
+
 .sff-profile-field {
     display: flex;
+    align-items: center;
     justify-content: space-between;
-    padding: 8px 0;
-    border-bottom: 1px solid #f0f0f0;
+    padding: 12px 15px;
+    margin-bottom: 10px;
+    background: #F9FAFB;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.05);
 }
 
 .sff-profile-field:last-child {
-    border-bottom: none;
+    margin-bottom: 0;
 }
 
 .sff-profile-field label {
     font-weight: 600;
     color: #3b3f5c;
+}
+
+.sff-profile-field label::before {
+    content: "\1F4DD"; /* 📝 */
+    margin-right: 8px;
 }
 
 .sff-profile-field span {
@@ -243,49 +257,10 @@
     background: #f0f0f0;
 }
 
-/* Profile Modal */
-.sff-modal {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background: rgba(0, 0, 0, 0.5);
-    display: none;
-    align-items: center;
-    justify-content: center;
-    z-index: 10000;
-}
-
-.sff-modal-content {
-    background: #ffffff;
-    border-radius: 12px;
-    max-width: 600px;
-    width: 90%;
-    max-height: 90%;
-    overflow: auto;
-    position: relative;
-    padding: 20px;
-}
-
-.sff-modal-close {
-    position: absolute;
-    top: 10px;
-    right: 15px;
-    background: none;
-    border: none;
-    font-size: 24px;
-    cursor: pointer;
-}
-
 @media (max-width: 768px) {
     .sff-menu-items {
         top: 50px;
         right: 0;
-    }
-
-    .sff-modal-content {
-        width: 95%;
     }
 
     .sff-profile-field {

--- a/wp-content/plugins/simplified-food-fitness/assets/js/sff-scripts.js
+++ b/wp-content/plugins/simplified-food-fitness/assets/js/sff-scripts.js
@@ -291,34 +291,6 @@ jQuery(document).ready(function($) {
   $('#sff-menu-toggle').on('click', function () {
     $('#sff-menu').toggle();
   });
-
-  // Load profile via AJAX when menu item is clicked
-  $('#sff-profile-link').on('click', function (e) {
-    e.preventDefault();
-    $('#sff-menu').hide();
-    $('#sff-profile-modal').fadeIn();
-    $('#sff-profile-content').html('<p>Loading...</p>');
-    $.post(
-      sff_ajax_obj.ajax_url,
-      { action: 'sff_load_profile', security: sff_ajax_obj.nonce },
-      function (response) {
-        $('#sff-profile-content').html(response);
-      }
-    );
-  });
-
-  function closeProfileModal() {
-    $('#sff-profile-modal').fadeOut();
-    $('#sff-profile-content').empty();
-  }
-
-  $('.sff-modal-close').on('click', closeProfileModal);
-
-  $('#sff-profile-modal').on('click', function (e) {
-    if (e.target.id === 'sff-profile-modal') {
-      closeProfileModal();
-    }
-  });
 });
 
 

--- a/wp-content/plugins/simplified-food-fitness/includes/shortcodes.php
+++ b/wp-content/plugins/simplified-food-fitness/includes/shortcodes.php
@@ -177,7 +177,7 @@ function sff_frontend_dashboard_pretty() {
             <div class="sff-hamburger-wrapper" style="position:relative;">
                 <button id="sff-menu-toggle" class="sff-hamburger">&#9776;</button>
                 <div id="sff-menu" class="sff-menu-items">
-                    <a href="#" id="sff-profile-link">Profile</a>
+                    <a href="<?php echo esc_url( home_url( '/my-profile/' ) ); ?>" id="sff-profile-link">Profile</a>
                 </div>
             </div>
         </div>
@@ -256,14 +256,6 @@ function sff_frontend_dashboard_pretty() {
                     Add Meal +
                 </button>
             </div>
-        </div>
-    </div>
-
-    <!-- Profile Modal -->
-    <div id="sff-profile-modal" class="sff-modal" style="display:none;">
-        <div class="sff-modal-content">
-            <button class="sff-modal-close" aria-label="Close">&times;</button>
-            <div id="sff-profile-content"></div>
         </div>
     </div>
 

--- a/wp-content/plugins/simplified-food-fitness/simplified-food-fitness.php
+++ b/wp-content/plugins/simplified-food-fitness/simplified-food-fitness.php
@@ -50,3 +50,18 @@ function sff_client_leads_logo_header() {
     echo '</div>';
 }
 // add_action('wp_head', 'sff_client_leads_logo_header');
+
+// Create profile page with client profile shortcode on activation
+function sff_create_profile_page() {
+    $slug = 'my-profile';
+    if (!get_page_by_path($slug)) {
+        wp_insert_post([
+            'post_title'   => 'My Profile',
+            'post_name'    => $slug,
+            'post_status'  => 'publish',
+            'post_type'    => 'page',
+            'post_content' => '[sff_client_profile]'
+        ]);
+    }
+}
+register_activation_hook(__FILE__, 'sff_create_profile_page');


### PR DESCRIPTION
## Summary
- Create "My Profile" page on plugin activation embedding `[sff_client_profile]`
- Link dashboard profile menu to the new page and drop AJAX modal markup & script
- Style profile fields with card layout and emoji icons

## Testing
- `php -l wp-content/plugins/simplified-food-fitness/includes/shortcodes.php`
- `php -l wp-content/plugins/simplified-food-fitness/simplified-food-fitness.php`


------
https://chatgpt.com/codex/tasks/task_e_689e347af8508329b61c55b966fe937a