### PR TITLE
Add overlay mobile navigation menu

### DIFF
--- a/wp-content/plugins/simplified-food-fitness/assets/css/sff-styles.css
+++ b/wp-content/plugins/simplified-food-fitness/assets/css/sff-styles.css
@@ -234,27 +234,39 @@
 }
 
 .sff-menu-items {
-    position: absolute;
-    top: 60px;
-    right: 0;
-    background: #ffffff;
-    border: 1px solid #e0e0e0;
-    border-radius: 8px;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(255, 255, 255, 0.95);
     display: none;
     flex-direction: column;
-    min-width: 150px;
+    justify-content: center;
+    align-items: center;
     z-index: 1000;
 }
 
-.sff-menu-items.is-visible {
+body.sff-menu-open .sff-menu-items {
     display: flex;
+}
+
+.sff-menu-items ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    text-align: center;
+}
+
+.sff-menu-items li {
+    margin: 20px 0;
 }
 
 .sff-menu-items a {
     padding: 10px 15px;
     color: #1f1f1f;
     text-decoration: none;
+    font-size: 24px;
 }
 
 .sff-menu-items a:hover {
@@ -262,11 +274,6 @@
 }
 
 @media (max-width: 768px) {
-    .sff-menu-items {
-        top: 50px;
-        right: 0;
-    }
-
     .sff-profile-field {
         flex-direction: column;
         align-items: flex-start;

--- a/wp-content/plugins/simplified-food-fitness/assets/js/sff-scripts.js
+++ b/wp-content/plugins/simplified-food-fitness/assets/js/sff-scripts.js
@@ -290,7 +290,12 @@ jQuery(document).ready(function($) {
   // Hamburger menu toggle
   $(document).on('click', '#sff-menu-toggle', function (e) {
     e.preventDefault();
-    $('#sff-menu').toggleClass('is-visible');
+    $('body').toggleClass('sff-menu-open');
+  });
+
+  // Close menu when a link is clicked
+  $(document).on('click', '#sff-menu a', function () {
+    $('body').removeClass('sff-menu-open');
   });
 });
 

--- a/wp-content/plugins/simplified-food-fitness/includes/shortcodes.php
+++ b/wp-content/plugins/simplified-food-fitness/includes/shortcodes.php
@@ -176,9 +176,13 @@ function sff_frontend_dashboard_pretty() {
             <!-- Hamburger Menu -->
             <div class="sff-hamburger-wrapper" style="position:relative;">
                 <button id="sff-menu-toggle" class="sff-hamburger">&#9776;</button>
-                <div id="sff-menu" class="sff-menu-items">
-                    <a href="<?php echo esc_url( home_url( '/my-profile/' ) ); ?>" id="sff-profile-link">Profile</a>
-                </div>
+                <nav id="sff-menu" class="sff-menu-items" aria-label="Mobile Menu">
+                    <ul>
+                        <li><a href="<?php echo esc_url( home_url( '/dashboard/' ) ); ?>">Dashboard</a></li>
+                        <li><a href="<?php echo esc_url( home_url( '/my-profile/' ) ); ?>" id="sff-profile-link">Profile</a></li>
+                        <li><a href="<?php echo esc_url( wp_logout_url( home_url() ) ); ?>">Logout</a></li>
+                    </ul>
+                </nav>
             </div>
         </div>
 


### PR DESCRIPTION
## Summary
- Wrap dashboard menu links in a `<nav>` and list items for Dashboard, Profile, and Logout
- Style menu as a full-screen overlay and show it when body has `sff-menu-open`
- Toggle menu visibility via JS and close on link click

## Testing
- `php -l wp-content/plugins/simplified-food-fitness/includes/shortcodes.php`
- `node --check wp-content/plugins/simplified-food-fitness/assets/js/sff-scripts.js && echo 'JS syntax OK'`


------
https://chatgpt.com/codex/tasks/task_e_689e442d5454832981fbc89f80d2859b