### PR TITLE
Add recipe post type and integrate with meal plans

### DIFF
--- a/wp-content/plugins/simplified-food-fitness/includes/helpers.php
+++ b/wp-content/plugins/simplified-food-fitness/includes/helpers.php
@@ -241,6 +241,29 @@ function sff_custom_login_form() {
     return ob_get_clean();
 }
 
+function sff_get_recipe_macros_from_ids($ingredient_ids) {
+    $totals = ['calories' => 0, 'carbs' => 0, 'protein' => 0, 'fat' => 0];
+    if (!is_array($ingredient_ids)) {
+        return $totals;
+    }
+    foreach ($ingredient_ids as $ingredient_id) {
+        $macros = get_post_meta($ingredient_id, '_sff_macros', true);
+        if (!is_array($macros)) {
+            continue;
+        }
+        $totals['calories'] += floatval($macros['calories'] ?? 0);
+        $totals['carbs'] += floatval($macros['carbs'] ?? 0);
+        $totals['protein'] += floatval($macros['protein'] ?? 0);
+        $totals['fat'] += floatval($macros['fat'] ?? 0);
+    }
+    return $totals;
+}
+
+function sff_get_recipe_macros($recipe_id) {
+    $ingredient_ids = get_post_meta($recipe_id, '_sff_recipe_ingredients', true);
+    return sff_get_recipe_macros_from_ids($ingredient_ids);
+}
+
 function sff_admin_notice() {
     if (isset($_GET['ingredient_saved']) && $_GET['ingredient_saved'] == 'true') {
         echo '<div class="updated notice is-dismissible"><p>✅ Ingredient has been saved successfully!</p></div>';

--- a/wp-content/plugins/simplified-food-fitness/includes/post-types.php
+++ b/wp-content/plugins/simplified-food-fitness/includes/post-types.php
@@ -38,6 +38,17 @@ function sff_register_custom_post_types() {
         'menu_icon' => 'dashicons-carrot'
     ]);
 
+    register_post_type('recipe', [
+        'labels' => [
+            'name' => __('Recipes'),
+            'singular_name' => __('Recipe')
+        ],
+        'public' => false,
+        'show_ui' => true,
+        'supports' => ['title', 'editor', 'thumbnail', 'custom-fields'],
+        'menu_icon' => 'dashicons-book-alt'
+    ]);
+
     register_post_type('client_leads', [
     'labels' => [
         'name' => __('Leads'),


### PR DESCRIPTION
## Summary
- Introduce `recipe` custom post type for composing meals from ingredients
- Allow selecting ingredients in recipe editor and store aggregated macro totals
- Enable picking a recipe in meal plan meta box and auto-fill macros from the recipe

## Testing
- `php -l wp-content/plugins/simplified-food-fitness/includes/post-types.php`
- `php -l wp-content/plugins/simplified-food-fitness/includes/meta-boxes.php`
- `php -l wp-content/plugins/simplified-food-fitness/includes/helpers.php`


------
https://chatgpt.com/codex/tasks/task_e_689e552904c48329b1fcfd9195cef743