### PR TITLE
Add user meal plan dashboard with progress tracking

### DIFF
--- a/wp-content/plugins/simplified-food-fitness/assets/js/dashboard.js
+++ b/wp-content/plugins/simplified-food-fitness/assets/js/dashboard.js
@@ -1,0 +1,36 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const checkboxes = document.querySelectorAll('.sff-meal-progress');
+    const bar = document.getElementById('sff-progress-bar');
+    const text = document.getElementById('sff-progress-text');
+
+    function updateDisplay() {
+        const total = checkboxes.length;
+        const completed = Array.from(checkboxes).filter(cb => cb.checked).length;
+        if (bar) {
+            bar.max = total;
+            bar.value = completed;
+        }
+        if (text) {
+            text.textContent = `${completed}/${total} meals completed`;
+        }
+    }
+
+    checkboxes.forEach(cb => {
+        cb.addEventListener('change', function() {
+            updateDisplay();
+            const formData = new URLSearchParams();
+            formData.append('action', 'sff_update_meal_progress');
+            formData.append('meal_id', this.dataset.mealId);
+            formData.append('completed', this.checked ? '1' : '0');
+            formData.append('nonce', sff_dashboard.nonce);
+
+            fetch(sff_dashboard.ajax_url, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                body: formData.toString()
+            });
+        });
+    });
+
+    updateDisplay();
+});

--- a/wp-content/plugins/simplified-food-fitness/includes/ajax.php
+++ b/wp-content/plugins/simplified-food-fitness/includes/ajax.php
@@ -713,6 +713,37 @@ function sff_convert_to_client() {
     ]);
 }
 
+// Save meal completion progress
+function sff_update_meal_progress() {
+    check_ajax_referer('sff_dashboard_nonce', 'nonce');
+
+    if (!is_user_logged_in()) {
+        wp_send_json_error('not_logged_in');
+    }
+
+    $meal_id  = isset($_POST['meal_id']) ? (int) $_POST['meal_id'] : 0;
+    $complete = isset($_POST['completed']) && '1' === $_POST['completed'];
+
+    $user_id = get_current_user_id();
+    $progress = get_user_meta($user_id, 'sff_meal_progress', true);
+    if (!is_array($progress)) {
+        $progress = [];
+    }
+
+    if ($complete) {
+        if (!in_array($meal_id, $progress)) {
+            $progress[] = $meal_id;
+        }
+    } else {
+        $progress = array_diff($progress, [$meal_id]);
+    }
+
+    update_user_meta($user_id, 'sff_meal_progress', $progress);
+
+    wp_send_json_success(['progress' => $progress]);
+}
+add_action('wp_ajax_sff_update_meal_progress', 'sff_update_meal_progress');
+
 // Load client profile via AJAX
 add_action('wp_ajax_sff_load_profile', 'sff_load_profile');
 add_action('wp_ajax_nopriv_sff_load_profile', 'sff_load_profile');

--- a/wp-content/plugins/simplified-food-fitness/includes/enqueue.php
+++ b/wp-content/plugins/simplified-food-fitness/includes/enqueue.php
@@ -22,6 +22,20 @@ function sff_enqueue_assets() {
         'nonce'    => wp_create_nonce('sff_scan_nonce')
     ]);
 
+    // Dashboard interactions
+    wp_enqueue_script(
+        'sff-dashboard',
+        SFF_PLUGIN_URL . 'assets/js/dashboard.js',
+        [],
+        '1.0.0',
+        true
+    );
+
+    wp_localize_script('sff-dashboard', 'sff_dashboard', [
+        'ajax_url' => admin_url('admin-ajax.php'),
+        'nonce'    => wp_create_nonce('sff_dashboard_nonce'),
+    ]);
+
     // ✅ CSS
     wp_enqueue_style('sff-styles', SFF_PLUGIN_URL . 'assets/css/sff-styles.css', [], '1.0.2');
 }

--- a/wp-content/plugins/simplified-food-fitness/templates/dashboard.php
+++ b/wp-content/plugins/simplified-food-fitness/templates/dashboard.php
@@ -1,0 +1,20 @@
+<?php
+/* Template Name: SFF Dashboard */
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+// Ensure plugin styles are loaded
+echo '<link rel="stylesheet" href="' . SFF_PLUGIN_URL . 'assets/css/sff-styles.css?ver=1.0.2">';
+
+if (!is_user_logged_in()) {
+    if (function_exists('sff_custom_login_form')) {
+        echo sff_custom_login_form();
+    } else {
+        wp_login_form();
+    }
+    return;
+}
+
+echo do_shortcode('[sff_meal_dashboard]');
+?>


### PR DESCRIPTION
## Summary
- add dashboard page template and meal plan shortcode pulling assigned plans
- track meal completion and grocery list with user meta
- wire up dashboard script for real-time progress updates

## Testing
- `php -l wp-content/plugins/simplified-food-fitness/templates/dashboard.php`
- `php -l wp-content/plugins/simplified-food-fitness/includes/shortcodes.php`
- `php -l wp-content/plugins/simplified-food-fitness/includes/enqueue.php`
- `php -l wp-content/plugins/simplified-food-fitness/includes/ajax.php`


------
https://chatgpt.com/codex/tasks/task_e_689e5a00be4883299eb4f1af91eab765