### PR TITLE
Add caching for recipe macros and lazy-load dashboard ingredients

### DIFF
--- a/wp-content/plugins/simplified-food-fitness/assets/js/ingredient-observer.js
+++ b/wp-content/plugins/simplified-food-fitness/assets/js/ingredient-observer.js
@@ -1,0 +1,48 @@
+(document => {
+  const placeholders = document.querySelectorAll('.sff-ingredients-placeholder');
+  if (!('IntersectionObserver' in window) || placeholders.length === 0) return;
+
+  const observer = new IntersectionObserver(entries => {
+    entries.forEach(entry => {
+      if (entry.isIntersecting) {
+        const el = entry.target;
+        const recipeId = el.getAttribute('data-recipe-id');
+        fetch(sff_ingredient_loader.ajax_url, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8' },
+          body: new URLSearchParams({
+            action: 'sff_fetch_ingredients',
+            recipe_id: recipeId,
+            nonce: sff_ingredient_loader.nonce
+          })
+        })
+          .then(res => res.json())
+          .then(data => {
+            if (data.success && Array.isArray(data.data)) {
+              const container = document.createElement('div');
+              container.className = 'sff-ingredients';
+              const title = document.createElement('h4');
+              title.textContent = 'Ingredients';
+              const ul = document.createElement('ul');
+              data.data.forEach(name => {
+                const li = document.createElement('li');
+                li.textContent = name;
+                ul.appendChild(li);
+              });
+              container.appendChild(title);
+              container.appendChild(ul);
+              el.replaceWith(container);
+            } else {
+              el.textContent = 'Failed to load ingredients';
+            }
+          })
+          .catch(() => {
+            el.textContent = 'Failed to load ingredients';
+          });
+        observer.unobserve(el);
+      }
+    });
+  });
+
+  placeholders.forEach(el => observer.observe(el));
+})(document);

--- a/wp-content/plugins/simplified-food-fitness/includes/ajax.php
+++ b/wp-content/plugins/simplified-food-fitness/includes/ajax.php
@@ -729,3 +729,22 @@ function sff_load_profile() {
     echo do_shortcode('[sff_client_profile]');
     wp_die();
 }
+
+add_action('wp_ajax_sff_fetch_ingredients', 'sff_fetch_ingredients');
+add_action('wp_ajax_nopriv_sff_fetch_ingredients', 'sff_fetch_ingredients');
+
+function sff_fetch_ingredients() {
+    check_ajax_referer('sff_ingredient_nonce', 'nonce');
+    $recipe_id = intval($_POST['recipe_id'] ?? 0);
+    if (!$recipe_id) {
+        wp_send_json_error('Invalid recipe');
+    }
+    $ingredient_ids = get_post_meta($recipe_id, '_sff_recipe_ingredients', true);
+    $ingredients    = [];
+    if (is_array($ingredient_ids)) {
+        foreach ($ingredient_ids as $ingredient_id) {
+            $ingredients[] = get_the_title($ingredient_id);
+        }
+    }
+    wp_send_json_success($ingredients);
+}

--- a/wp-content/plugins/simplified-food-fitness/includes/enqueue.php
+++ b/wp-content/plugins/simplified-food-fitness/includes/enqueue.php
@@ -22,6 +22,18 @@ function sff_enqueue_assets() {
         'nonce'    => wp_create_nonce('sff_scan_nonce')
     ]);
 
+    wp_enqueue_script(
+        'sff-ingredient-loader',
+        SFF_PLUGIN_URL . 'assets/js/ingredient-observer.js',
+        [],
+        '1.0.0',
+        true
+    );
+    wp_localize_script('sff-ingredient-loader', 'sff_ingredient_loader', [
+        'ajax_url' => admin_url('admin-ajax.php'),
+        'nonce'    => wp_create_nonce('sff_ingredient_nonce')
+    ]);
+
     // ✅ CSS
     wp_enqueue_style('sff-styles', SFF_PLUGIN_URL . 'assets/css/sff-styles.css', [], '1.0.2');
 }


### PR DESCRIPTION
## Summary
- Cache recipe macro totals with transients keyed by recipe ID and last modified time
- Clear macro cache on recipe save
- Lazy-load long ingredient lists via IntersectionObserver and AJAX

## Testing
- `php -l wp-content/plugins/simplified-food-fitness/includes/helpers.php`
- `php -l wp-content/plugins/simplified-food-fitness/includes/ajax.php`
- `php -l wp-content/plugins/simplified-food-fitness/includes/enqueue.php`


------
https://chatgpt.com/codex/tasks/task_e_689e5a184fd4832995514d5b66427b28