### PR TITLE
Ensure busy/activity day fields only required when visible

### DIFF
--- a/wp-content/plugins/simplified-food-fitness/assets/js/sff-scripts.js
+++ b/wp-content/plugins/simplified-food-fitness/assets/js/sff-scripts.js
@@ -367,6 +367,25 @@ jQuery(document).ready(function($) {
       }
     });
   });
+
+  // Ensure busy/activity day fields are only required when visible
+  function toggleClientDayRequired(selector) {
+    var fields = $(selector);
+    if (!fields.length) return;
+    function toggle() {
+      fields.each(function () {
+        $(this).prop('required', $(this).is(':visible'));
+      });
+    }
+    toggle();
+    const observer = new MutationObserver(toggle);
+    fields.each(function () {
+      observer.observe(this, { attributes: true, attributeFilter: ['style', 'class'] });
+    });
+  }
+
+  toggleClientDayRequired('[name="client[]busy_days"]');
+  toggleClientDayRequired('[name="client[]activity_days"]');
 });
 
 


### PR DESCRIPTION
## Summary
- Dynamically toggle `required` attributes for `client[]busy_days` and `client[]activity_days`
- Watch for visibility changes and adjust validation on the fly

## Testing
- `npm test` *(fails: could not find package.json)*
- `node --check wp-content/plugins/simplified-food-fitness/assets/js/sff-scripts.js`


------
https://chatgpt.com/codex/tasks/task_e_68ac68aae3c48329a068014e2ba35450