### PR TITLE
Compute macro grams from percentages

### DIFF
--- a/wp-content/plugins/simplified-food-fitness/includes/meta-boxes.php
+++ b/wp-content/plugins/simplified-food-fitness/includes/meta-boxes.php
@@ -476,11 +476,23 @@ function sff_save_macro_target_meta_box($post_id) {
         return;
     }
 
+    $calories       = floatval($_POST['calories']);
+    $carb_percent    = isset($_POST['carb_percent']) ? floatval($_POST['carb_percent']) : 0;
+    $protein_percent = isset($_POST['protein_percent']) ? floatval($_POST['protein_percent']) : 0;
+    $fat_percent     = isset($_POST['fat_percent']) ? floatval($_POST['fat_percent']) : 0;
+
+    $carbs   = $calories * $carb_percent / 400;
+    $protein = $calories * $protein_percent / 400;
+    $fats    = $calories * $fat_percent / 900;
+
     $macros = [
-        'calories' => $_POST['calories'],
-        'protein'  => $_POST['protein'],
-        'carbs'    => $_POST['carbs'],
-        'fats'     => $_POST['fats'],
+        'calories'        => $calories,
+        'carb_percent'    => $carb_percent,
+        'protein_percent' => $protein_percent,
+        'fat_percent'     => $fat_percent,
+        'carbs'           => $carbs,
+        'protein'         => $protein,
+        'fats'            => $fats,
     ];
 
     $micros = [

--- a/wp-content/plugins/simplified-food-fitness/includes/shortcodes.php
+++ b/wp-content/plugins/simplified-food-fitness/includes/shortcodes.php
@@ -306,13 +306,15 @@ function sff_frontend_dashboard_pretty() {
         'post_status'    => 'publish',
         'posts_per_page' => 1,
     );
-    $macro_post = get_posts($args);
+    $macro_post   = get_posts($args);
     $macro_post_id = $macro_post ? $macro_post[0]->ID : null;
 
+    $macro_targets = $macro_post_id ? get_post_meta($macro_post_id, '_macro_targets', true) : [];
+
     // 🔥 Fetch saved macro percentages or use defaults
-    $carb_percent = $macro_post_id ? get_post_meta($macro_post_id, 'carb_percent', true) : '';
-    $protein_percent = $macro_post_id ? get_post_meta($macro_post_id, 'protein_percent', true) : '';
-    $fat_percent = $macro_post_id ? get_post_meta($macro_post_id, 'fat_percent', true) : '';
+    $carb_percent    = $macro_targets['carb_percent'] ?? ($macro_post_id ? get_post_meta($macro_post_id, 'carb_percent', true) : '');
+    $protein_percent = $macro_targets['protein_percent'] ?? ($macro_post_id ? get_post_meta($macro_post_id, 'protein_percent', true) : '');
+    $fat_percent     = $macro_targets['fat_percent'] ?? ($macro_post_id ? get_post_meta($macro_post_id, 'fat_percent', true) : '');
 
     if (!$carb_percent) {
         $carb_percent = 40; // Default from ajax.php
@@ -325,15 +327,15 @@ function sff_frontend_dashboard_pretty() {
     }
 
     // 🔥 Fetch total calories or fallback to 2000
-    $total_calories = $macro_post_id ? get_post_meta($macro_post_id, 'calories', true) : 2000;
+    $total_calories = $macro_targets['calories'] ?? ($macro_post_id ? get_post_meta($macro_post_id, 'calories', true) : 2000);
     if (!$total_calories) {
         $total_calories = 2000; // fallback default
     }
 
-    // 🔥 Calculate grams for macros
-    $carbs_goal_g = ($carb_percent / 100) * $total_calories / 4; // 4 cal/g carbs
-    $protein_goal_g = ($protein_percent / 100) * $total_calories / 4; // 4 cal/g protein
-    $fat_goal_g = ($fat_percent / 100) * $total_calories / 9; // 9 cal/g fat
+    // 🔥 Use stored grams or compute from percentages
+    $carbs_goal_g   = $macro_targets['carbs']   ?? ($total_calories * $carb_percent / 400);
+    $protein_goal_g = $macro_targets['protein'] ?? ($total_calories * $protein_percent / 400);
+    $fat_goal_g     = $macro_targets['fats']    ?? ($total_calories * $fat_percent / 900);
 
     // 🔥 Example: current intake (replace these with dynamic values if you track)
     $carbs_current_g = 135;
@@ -452,7 +454,7 @@ function sff_frontend_macro_micro_targets() {
     }
 
     $post_id = $macro_post[0]->ID;
-    $macros = get_post_meta($post_id, '_macro_target', true);
+    $macros = get_post_meta($post_id, '_macro_targets', true);
     $micros = get_post_meta($post_id, '_micro_targets', true);
 
     // Logo URL (replace with your actual logo URL)


### PR DESCRIPTION
## Summary
- Recalculate macro grams when saving macro target posts based on calories and stored percentages
- Persist grams and percent values together for macro targets
- Display stored macro gram goals in dashboard and macro/micro target shortcode

## Testing
- `php -l wp-content/plugins/simplified-food-fitness/includes/meta-boxes.php`
- `php -l wp-content/plugins/simplified-food-fitness/includes/shortcodes.php`


------
https://chatgpt.com/codex/tasks/task_e_68ac8f7d12808329bc990efdcbff5109