### PR TITLE
Fix macro target metabox registration

### DIFF
--- a/wp-content/plugins/simplified-food-fitness/includes/meta-boxes.php
+++ b/wp-content/plugins/simplified-food-fitness/includes/meta-boxes.php
@@ -619,7 +619,7 @@ add_action('add_meta_boxes', function () {
         'macro_percentages_meta_box',
         'Macro Percentages',
         'render_macro_percentages_meta_box',
-        'macro_targets', // your CPT name
+        'macro_target', // CPT slug
         'normal',
         'high'
     );
@@ -644,7 +644,7 @@ function render_macro_percentages_meta_box($post) {
 }
 
 // Save the custom fields when the post is saved
-add_action('save_post_macro_targets', function ($post_id) {
+add_action('save_post_macro_target', function ($post_id) {
     if (isset($_POST['carb_percent'])) {
         update_post_meta($post_id, 'carb_percent', intval($_POST['carb_percent']));
     }


### PR DESCRIPTION
## Summary
- Register Macro Percentages metabox for the `macro_target` post type
- Adjust save handler to hook into `save_post_macro_target`

## Testing
- `php -l wp-content/plugins/simplified-food-fitness/includes/meta-boxes.php`


------
https://chatgpt.com/codex/tasks/task_e_68b0a29afff08329bd9f95215be2cd7c