### PR TITLE
Remove custom fields support from macro target post type

### DIFF
--- a/wp-content/plugins/simplified-food-fitness/includes/post-types.php
+++ b/wp-content/plugins/simplified-food-fitness/includes/post-types.php
@@ -23,7 +23,8 @@ function sff_register_custom_post_types() {
         'public' => false,
         'has_archive' => false,
         'show_ui' => true,
-        'supports' => ['title', 'custom-fields'],
+        // Removed default custom fields to keep the UI clean. Bespoke meta boxes handle data entry.
+        'supports' => ['title'],
         'menu_icon' => 'dashicons-chart-bar',
     ]);
 


### PR DESCRIPTION
## Summary
- remove custom-fields support from macro_target custom post type to hide default custom fields UI

## Testing
- `php -l wp-content/plugins/simplified-food-fitness/includes/post-types.php`


------
https://chatgpt.com/codex/tasks/task_e_68b0a114dd088329a5ae5716fe61455a