### PR TITLE
Redirect clients to unified dashboard

### DIFF
--- a/wp-content/plugins/simplified-food-fitness/includes/ajax.php
+++ b/wp-content/plugins/simplified-food-fitness/includes/ajax.php
@@ -760,7 +760,7 @@ function sff_convert_to_client() {
     }
 
     // ✅ Email user credentials
-    $login_url = wp_login_url(site_url('/client-dashboard/'));
+    $login_url = wp_login_url(site_url('/dashboard/'));
     wp_new_user_notification($user_id, null, 'user');
 
     wp_send_json_success([

--- a/wp-content/plugins/simplified-food-fitness/includes/helpers.php
+++ b/wp-content/plugins/simplified-food-fitness/includes/helpers.php
@@ -224,7 +224,7 @@ add_action('save_post', 'sff_save_ingredient_details');
 function sff_custom_login_form() {
    $args = array(
         'echo'           => false,
-        'redirect'       => (is_ssl() ? 'https://' : 'http://') . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'],
+        'redirect'       => home_url('/dashboard/'),
         'label_username' => __('Username or Email'),
         'label_password' => __('Password'),
         'label_remember' => __('Remember Me'),

--- a/wp-content/plugins/simplified-food-fitness/simplified-food-fitness.php
+++ b/wp-content/plugins/simplified-food-fitness/simplified-food-fitness.php
@@ -154,3 +154,20 @@ function sff_plugin_update_check() {
     }
 }
 add_action('init', 'sff_plugin_update_check', 20);
+
+// Redirect clients and customers to dashboard on login
+function sff_login_redirect($redirect_to, $request, $user) {
+    if (isset($user->roles) && (in_array('client', $user->roles) || in_array('customer', $user->roles))) {
+        return home_url('/dashboard/');
+    }
+    return $redirect_to;
+}
+add_filter('login_redirect', 'sff_login_redirect', 10, 3);
+
+function sff_woocommerce_login_redirect($redirect, $user) {
+    if (isset($user->roles) && (in_array('client', $user->roles) || in_array('customer', $user->roles))) {
+        return home_url('/dashboard/');
+    }
+    return $redirect;
+}
+add_filter('woocommerce_login_redirect', 'sff_woocommerce_login_redirect', 10, 2);


### PR DESCRIPTION
## Summary
- Redirect new accounts emails and login flow to `/dashboard/`
- Route client/customer logins (including WooCommerce) to dashboard
- Ensure manual login form defaults to the dashboard after authentication

## Testing
- `php -l wp-content/plugins/simplified-food-fitness/includes/ajax.php`
- `php -l wp-content/plugins/simplified-food-fitness/simplified-food-fitness.php`
- `php -l wp-content/plugins/simplified-food-fitness/includes/helpers.php`


------
https://chatgpt.com/codex/tasks/task_e_68b0aa7855588329ae837404dcf6210b