### PR TITLE
feat: calculate per-serving recipe macros

### DIFF
--- a/wp-content/plugins/simplified-food-fitness/includes/helpers.php
+++ b/wp-content/plugins/simplified-food-fitness/includes/helpers.php
@@ -62,10 +62,51 @@ function sff_generate_meal_cards($meal_plan) {
     return $output;
 }
 
+function sff_fetch_usda_macros($fdc_id) {
+    $api_key = defined('SFF_USDA_API_KEY') ? SFF_USDA_API_KEY : '';
+    if (empty($api_key) || empty($fdc_id)) {
+        return [];
+    }
+
+    $url = 'https://api.nal.usda.gov/fdc/v1/food/' . intval($fdc_id) . '?api_key=' . urlencode($api_key);
+    $response = wp_remote_get($url, ['timeout' => 15]);
+    if (is_wp_error($response)) {
+        return [];
+    }
+
+    $data = json_decode(wp_remote_retrieve_body($response), true);
+    if (empty($data['foodNutrients'])) {
+        return [];
+    }
+
+    $macros = ['calories' => 0, 'carbs' => 0, 'protein' => 0, 'fat' => 0];
+    foreach ($data['foodNutrients'] as $nutrient) {
+        $name  = $nutrient['nutrientName'] ?? '';
+        $value = isset($nutrient['value']) ? floatval($nutrient['value']) : 0;
+        switch ($name) {
+            case 'Energy':
+                $macros['calories'] = $value;
+                break;
+            case 'Carbohydrate, by difference':
+                $macros['carbs'] = $value;
+                break;
+            case 'Protein':
+                $macros['protein'] = $value;
+                break;
+            case 'Total lipid (fat)':
+                $macros['fat'] = $value;
+                break;
+        }
+    }
+
+    return $macros;
+}
+
 function sff_render_ingredient_form($post_id = null) {
    // Get existing ingredient data if editing
     $brand_name = $serving_size = $servings = '';
     $front_image = $nutrition_label_image = '';
+    $fdc_id = '';
     $macros = [
         'calories' => 0, 'carbs' => 0, 'protein' => 0, 'fat' => 0, 
         'saturated_fat' => 0, 'trans_fat' => 0, 'cholesterol' => 0, 
@@ -82,6 +123,7 @@ function sff_render_ingredient_form($post_id = null) {
         $macros = get_post_meta($post_id, '_sff_macros', true) ?: $macros;
         $front_image = get_post_meta($post_id, '_sff_front_image', true);
         $nutrition_label_image = get_post_meta($post_id, '_sff_nutrition_label_image', true);
+        $fdc_id = get_post_meta($post_id, '_sff_fdc_id', true);
     }
 
     ob_start(); ?>
@@ -126,6 +168,9 @@ function sff_render_ingredient_form($post_id = null) {
 
         <label style="font-size:14px; color:#777;">Product Name:</label>
         <input type="text" name="sff_brand_name" id="sff_product_name" value="<?php echo esc_attr($brand_name); ?>" placeholder="e.g., Brand X" style="width:100%; padding:10px; border:1px solid #ccc; border-radius:6px; margin-bottom:10px;">
+
+        <label style="font-size:14px; color:#777;">USDA FDC ID (optional):</label>
+        <input type="text" name="sff_fdc_id" value="<?php echo esc_attr($fdc_id); ?>" placeholder="e.g., 123456" style="width:100%; padding:10px; border:1px solid #ccc; border-radius:6px; margin-bottom:10px;">
 
 
         <input type="file" id="sff_nutrition_label_upload" accept="image/*" style="width:100%; padding:10px; border:1px solid #ccc; border-radius:6px;">
@@ -194,12 +239,24 @@ function sff_save_ingredient_details($post_id) {
         update_post_meta($post_id, '_sff_brand_name', sanitize_text_field($_POST['sff_brand_name']));
     }
 
+    $fdc_id = '';
+    if (isset($_POST['sff_fdc_id'])) {
+        $fdc_id = sanitize_text_field($_POST['sff_fdc_id']);
+        update_post_meta($post_id, '_sff_fdc_id', $fdc_id);
+    }
+
     if (isset($_POST['sff_measurements'])) {
         update_post_meta($post_id, '_sff_measurements', sanitize_textarea_field($_POST['sff_measurements']));
     }
 
     if (isset($_POST['sff_macros'])) {
         $macros = array_map('sanitize_text_field', $_POST['sff_macros']);
+        if (array_sum(array_map('floatval', $macros)) === 0 && !empty($fdc_id)) {
+            $api_macros = sff_fetch_usda_macros($fdc_id);
+            foreach ($api_macros as $key => $value) {
+                $macros[$key] = $value;
+            }
+        }
         update_post_meta($post_id, '_sff_macros', $macros);
 
         global $wpdb;
@@ -306,9 +363,18 @@ function sff_get_recipe_macros_from_ids($ingredient_ids) {
     return $totals;
 }
 
-function sff_get_recipe_macros($recipe_id) {
+function sff_get_recipe_macros($recipe_id, $per_serving = false) {
     $ingredient_ids = get_post_meta($recipe_id, '_sff_recipe_ingredients', true);
-    return sff_get_recipe_macros_from_ids($ingredient_ids);
+    $totals = sff_get_recipe_macros_from_ids($ingredient_ids);
+    if ($per_serving) {
+        $servings = (int) get_post_meta($recipe_id, '_sff_recipe_servings', true);
+        if ($servings > 0) {
+            foreach ($totals as $key => $value) {
+                $totals[$key] = $value / $servings;
+            }
+        }
+    }
+    return $totals;
 }
 
 function sff_admin_notice() {

--- a/wp-content/plugins/simplified-food-fitness/includes/meta-boxes.php
+++ b/wp-content/plugins/simplified-food-fitness/includes/meta-boxes.php
@@ -395,7 +395,10 @@ function sff_render_recipe_meta_box($post) {
     if (!is_array($saved)) {
         $saved = [];
     }
+
+    $servings = get_post_meta($post->ID, '_sff_recipe_servings', true);
     $ingredients = get_posts(['post_type' => 'ingredient', 'numberposts' => -1]);
+
     echo '<label><strong>Ingredients:</strong></label>';
     echo '<select name="sff_recipe_ingredients[]" multiple style="width:100%; height:150px;">';
     foreach ($ingredients as $ingredient) {
@@ -403,23 +406,44 @@ function sff_render_recipe_meta_box($post) {
         echo '<option value="' . esc_attr($ingredient->ID) . '" ' . $selected . '>' . esc_html($ingredient->post_title) . '</option>';
     }
     echo '</select>';
+
+    echo '<p><label><strong>Servings:</strong></label> <input type="number" name="sff_recipe_servings" value="' . esc_attr($servings) . '" min="1" style="width:80px;" /></p>';
+
+    $totals = get_post_meta($post->ID, '_sff_recipe_macros_total', true);
     $macros = get_post_meta($post->ID, '_sff_recipe_macros', true);
     if (is_array($macros)) {
+        echo '<h4>Macros per serving</h4>';
         echo '<p><strong>Calories:</strong> ' . esc_html($macros['calories'] ?? 0) . '</p>';
         echo '<p><strong>Carbs:</strong> ' . esc_html($macros['carbs'] ?? 0) . 'g</p>';
         echo '<p><strong>Protein:</strong> ' . esc_html($macros['protein'] ?? 0) . 'g</p>';
         echo '<p><strong>Fat:</strong> ' . esc_html($macros['fat'] ?? 0) . 'g</p>';
+    }
+    if (is_array($totals)) {
+        echo '<h4>Total for recipe</h4>';
+        echo '<p><strong>Calories:</strong> ' . esc_html($totals['calories'] ?? 0) . '</p>';
+        echo '<p><strong>Carbs:</strong> ' . esc_html($totals['carbs'] ?? 0) . 'g</p>';
+        echo '<p><strong>Protein:</strong> ' . esc_html($totals['protein'] ?? 0) . 'g</p>';
+        echo '<p><strong>Fat:</strong> ' . esc_html($totals['fat'] ?? 0) . 'g</p>';
     }
 }
 
 function sff_save_recipe_details($post_id) {
     if (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) return;
     if (!current_user_can('edit_post', $post_id)) return;
+    if (isset($_POST['sff_recipe_servings'])) {
+        update_post_meta($post_id, '_sff_recipe_servings', absint($_POST['sff_recipe_servings']));
+    }
     if (isset($_POST['sff_recipe_ingredients'])) {
         $ingredient_ids = array_map('intval', (array) $_POST['sff_recipe_ingredients']);
         update_post_meta($post_id, '_sff_recipe_ingredients', $ingredient_ids);
         $totals = sff_get_recipe_macros_from_ids($ingredient_ids);
-        update_post_meta($post_id, '_sff_recipe_macros', $totals);
+        update_post_meta($post_id, '_sff_recipe_macros_total', $totals);
+        $servings = max(1, intval(get_post_meta($post_id, '_sff_recipe_servings', true)));
+        $per_serving = [];
+        foreach ($totals as $key => $value) {
+            $per_serving[$key] = $value / $servings;
+        }
+        update_post_meta($post_id, '_sff_recipe_macros', $per_serving);
     }
 }
 add_action('save_post', 'sff_save_recipe_details');

--- a/wp-content/plugins/simplified-food-fitness/simplified-food-fitness.php
+++ b/wp-content/plugins/simplified-food-fitness/simplified-food-fitness.php
@@ -26,6 +26,11 @@ if (!defined('SFF_MACRO_FIELDS')) {
     ]);
 }
 
+if (!defined('SFF_USDA_API_KEY')) {
+    // Expect the USDA API key to be provided via environment variable to avoid committing secrets.
+    define('SFF_USDA_API_KEY', getenv('USDA_API_KEY') ?: '');
+}
+
 // Include all feature files
 require_once SFF_PLUGIN_DIR . 'includes/post-types.php';
 require_once SFF_PLUGIN_DIR . 'includes/meta-boxes.php';


### PR DESCRIPTION
## Summary
- add recipe servings field to meta box and store per-serving and total macros
- support calculating macros per serving via helper function
- allow ingredients to pull macros from USDA FoodData Central using an optional FDC ID

## Testing
- `php -l wp-content/plugins/simplified-food-fitness/includes/meta-boxes.php`
- `php -l wp-content/plugins/simplified-food-fitness/includes/helpers.php`
- `php -l wp-content/plugins/simplified-food-fitness/simplified-food-fitness.php`


------
https://chatgpt.com/codex/tasks/task_e_68b0ae2fc8c483299f47aac87b7c9961