### PR TITLE
Enable dynamic recipe nutrient calculations

### DIFF
--- a/wp-content/plugins/simplified-food-fitness/assets/js/recipe-macros.js
+++ b/wp-content/plugins/simplified-food-fitness/assets/js/recipe-macros.js
@@ -1,0 +1,37 @@
+jQuery(function($){
+    function updateMacros(){
+        var ids = $('select[name="sff_recipe_ingredients[]"]').val() || [];
+        var servings = $('input[name="sff_recipe_servings"]').val() || 1;
+        $.post(sff_ajax_obj.ajax_url, {
+            action: 'sff_calc_recipe_macros',
+            security: sff_ajax_obj.nonce,
+            ingredients: ids,
+            servings: servings
+        }, function(resp){
+            if(!resp || !resp.success){return;}
+            var data = resp.data;
+            var $display = $('#sff-recipe-macro-display');
+            var html = '';
+            if(data.per_serving){
+                html += '<h4>Macros per serving</h4><ul class="per-serving">';
+                $.each(data.per_serving, function(key,val){
+                    var label = key.replace(/_/g,' ');
+                    html += '<li><strong>'+label+':</strong> '+val+'</li>';
+                });
+                html += '</ul>';
+            }
+            if(data.total){
+                html += '<h4>Total for recipe</h4><ul class="total">';
+                $.each(data.total, function(key,val){
+                    var label = key.replace(/_/g,' ');
+                    html += '<li><strong>'+label+':</strong> '+val+'</li>';
+                });
+                html += '</ul>';
+            }
+            $display.html(html);
+        });
+    }
+    $('select[name="sff_recipe_ingredients[]"], input[name="sff_recipe_servings"]').on('change', updateMacros);
+    // trigger on load to populate
+    updateMacros();
+});

--- a/wp-content/plugins/simplified-food-fitness/includes/ajax.php
+++ b/wp-content/plugins/simplified-food-fitness/includes/ajax.php
@@ -877,3 +877,29 @@ function sff_create_recipe() {
     ]);
 }
 add_action('wp_ajax_sff_create_recipe', 'sff_create_recipe');
+
+function sff_calc_recipe_macros() {
+    if (!isset($_POST['security']) || !wp_verify_nonce($_POST['security'], 'sff_scan_nonce')) {
+        wp_send_json_error('Nonce verification failed.');
+    }
+
+    $ingredient_ids = isset($_POST['ingredients']) ? array_map('intval', (array) $_POST['ingredients']) : [];
+    $servings = max(1, intval($_POST['servings'] ?? 1));
+
+    if (!function_exists('sff_get_recipe_macros_from_ids')) {
+        require_once SFF_PLUGIN_DIR . 'includes/helpers.php';
+    }
+
+    $totals = sff_get_recipe_macros_from_ids($ingredient_ids);
+    $per_serving = [];
+    foreach ($totals as $key => $value) {
+        $per_serving[$key] = $value / $servings;
+    }
+
+    wp_send_json_success([
+        'total' => $totals,
+        'per_serving' => $per_serving,
+    ]);
+}
+add_action('wp_ajax_sff_calc_recipe_macros', 'sff_calc_recipe_macros');
+add_action('wp_ajax_nopriv_sff_calc_recipe_macros', 'sff_calc_recipe_macros');

--- a/wp-content/plugins/simplified-food-fitness/includes/enqueue.php
+++ b/wp-content/plugins/simplified-food-fitness/includes/enqueue.php
@@ -3,7 +3,7 @@ if (!defined('ABSPATH')) {
     exit; // Exit if accessed directly
 }
 
-function sff_enqueue_assets() {
+function sff_enqueue_assets($hook = '') {
     // ✅ Load jQuery
     wp_enqueue_script('jquery');
 
@@ -35,6 +35,20 @@ function sff_enqueue_assets() {
         'ajax_url' => admin_url('admin-ajax.php'),
         'nonce'    => wp_create_nonce('sff_dashboard_nonce'),
     ]);
+
+    // Recipe editor macros updater (admin only)
+    if (is_admin()) {
+        $screen = function_exists('get_current_screen') ? get_current_screen() : null;
+        if ($screen && 'recipe' === $screen->post_type) {
+            wp_enqueue_script(
+                'sff-recipe-macros',
+                SFF_PLUGIN_URL . 'assets/js/recipe-macros.js',
+                ['jquery', 'sff-scripts'],
+                '1.0.0',
+                true
+            );
+        }
+    }
 
     // ✅ CSS
     wp_enqueue_style('sff-styles', SFF_PLUGIN_URL . 'assets/css/sff-styles.css', [], '1.0.2');

--- a/wp-content/plugins/simplified-food-fitness/includes/helpers.php
+++ b/wp-content/plugins/simplified-food-fitness/includes/helpers.php
@@ -62,10 +62,51 @@ function sff_generate_meal_cards($meal_plan) {
     return $output;
 }
 
+function sff_fetch_usda_macros($fdc_id) {
+    $api_key = defined('SFF_USDA_API_KEY') ? SFF_USDA_API_KEY : '';
+    if (empty($api_key) || empty($fdc_id)) {
+        return [];
+    }
+
+    $url = 'https://api.nal.usda.gov/fdc/v1/food/' . intval($fdc_id) . '?api_key=' . urlencode($api_key);
+    $response = wp_remote_get($url, ['timeout' => 15]);
+    if (is_wp_error($response)) {
+        return [];
+    }
+
+    $data = json_decode(wp_remote_retrieve_body($response), true);
+    if (empty($data['foodNutrients'])) {
+        return [];
+    }
+
+    $macros = ['calories' => 0, 'carbs' => 0, 'protein' => 0, 'fat' => 0];
+    foreach ($data['foodNutrients'] as $nutrient) {
+        $name  = $nutrient['nutrientName'] ?? '';
+        $value = isset($nutrient['value']) ? floatval($nutrient['value']) : 0;
+        switch ($name) {
+            case 'Energy':
+                $macros['calories'] = $value;
+                break;
+            case 'Carbohydrate, by difference':
+                $macros['carbs'] = $value;
+                break;
+            case 'Protein':
+                $macros['protein'] = $value;
+                break;
+            case 'Total lipid (fat)':
+                $macros['fat'] = $value;
+                break;
+        }
+    }
+
+    return $macros;
+}
+
 function sff_render_ingredient_form($post_id = null) {
    // Get existing ingredient data if editing
     $brand_name = $serving_size = $servings = '';
     $front_image = $nutrition_label_image = '';
+    $fdc_id = '';
     $macros = [
         'calories' => 0, 'carbs' => 0, 'protein' => 0, 'fat' => 0, 
         'saturated_fat' => 0, 'trans_fat' => 0, 'cholesterol' => 0, 
@@ -82,6 +123,7 @@ function sff_render_ingredient_form($post_id = null) {
         $macros = get_post_meta($post_id, '_sff_macros', true) ?: $macros;
         $front_image = get_post_meta($post_id, '_sff_front_image', true);
         $nutrition_label_image = get_post_meta($post_id, '_sff_nutrition_label_image', true);
+        $fdc_id = get_post_meta($post_id, '_sff_fdc_id', true);
     }
 
     ob_start(); ?>
@@ -126,6 +168,9 @@ function sff_render_ingredient_form($post_id = null) {
 
         <label style="font-size:14px; color:#777;">Product Name:</label>
         <input type="text" name="sff_brand_name" id="sff_product_name" value="<?php echo esc_attr($brand_name); ?>" placeholder="e.g., Brand X" style="width:100%; padding:10px; border:1px solid #ccc; border-radius:6px; margin-bottom:10px;">
+
+        <label style="font-size:14px; color:#777;">USDA FDC ID (optional):</label>
+        <input type="text" name="sff_fdc_id" value="<?php echo esc_attr($fdc_id); ?>" placeholder="e.g., 123456" style="width:100%; padding:10px; border:1px solid #ccc; border-radius:6px; margin-bottom:10px;">
 
 
         <input type="file" id="sff_nutrition_label_upload" accept="image/*" style="width:100%; padding:10px; border:1px solid #ccc; border-radius:6px;">
@@ -194,12 +239,24 @@ function sff_save_ingredient_details($post_id) {
         update_post_meta($post_id, '_sff_brand_name', sanitize_text_field($_POST['sff_brand_name']));
     }
 
+    $fdc_id = '';
+    if (isset($_POST['sff_fdc_id'])) {
+        $fdc_id = sanitize_text_field($_POST['sff_fdc_id']);
+        update_post_meta($post_id, '_sff_fdc_id', $fdc_id);
+    }
+
     if (isset($_POST['sff_measurements'])) {
         update_post_meta($post_id, '_sff_measurements', sanitize_textarea_field($_POST['sff_measurements']));
     }
 
     if (isset($_POST['sff_macros'])) {
         $macros = array_map('sanitize_text_field', $_POST['sff_macros']);
+        if (array_sum(array_map('floatval', $macros)) === 0 && !empty($fdc_id)) {
+            $api_macros = sff_fetch_usda_macros($fdc_id);
+            foreach ($api_macros as $key => $value) {
+                $macros[$key] = $value;
+            }
+        }
         update_post_meta($post_id, '_sff_macros', $macros);
 
         global $wpdb;
@@ -285,30 +342,39 @@ function sff_create_recipe_from_modal($name, $ingredient_ids) {
 }
 
 function sff_get_recipe_macros_from_ids($ingredient_ids) {
-    $totals = ['calories' => 0, 'carbs' => 0, 'protein' => 0, 'fat' => 0];
+    $totals = array_fill_keys(SFF_MACRO_FIELDS, 0);
     if (!is_array($ingredient_ids) || empty($ingredient_ids)) {
         return $totals;
     }
 
     global $wpdb;
     $table = $wpdb->prefix . 'sff_ingredient_nutrition';
+    $fields = implode(', ', SFF_MACRO_FIELDS);
     $placeholders = implode(',', array_fill(0, count($ingredient_ids), '%d'));
-    $query = $wpdb->prepare("SELECT calories, carbs, protein, fat FROM $table WHERE ingredient_id IN ($placeholders)", $ingredient_ids);
+    $query = $wpdb->prepare("SELECT $fields FROM $table WHERE ingredient_id IN ($placeholders)", $ingredient_ids);
     $results = $wpdb->get_results($query, ARRAY_A);
 
     foreach ($results as $row) {
-        $totals['calories'] += floatval($row['calories']);
-        $totals['carbs'] += floatval($row['carbs']);
-        $totals['protein'] += floatval($row['protein']);
-        $totals['fat'] += floatval($row['fat']);
+        foreach (SFF_MACRO_FIELDS as $field) {
+            $totals[$field] += isset($row[$field]) ? floatval($row[$field]) : 0;
+        }
     }
 
     return $totals;
 }
 
-function sff_get_recipe_macros($recipe_id) {
+function sff_get_recipe_macros($recipe_id, $per_serving = false) {
     $ingredient_ids = get_post_meta($recipe_id, '_sff_recipe_ingredients', true);
-    return sff_get_recipe_macros_from_ids($ingredient_ids);
+    $totals = sff_get_recipe_macros_from_ids($ingredient_ids);
+    if ($per_serving) {
+        $servings = (int) get_post_meta($recipe_id, '_sff_recipe_servings', true);
+        if ($servings > 0) {
+            foreach ($totals as $key => $value) {
+                $totals[$key] = $value / $servings;
+            }
+        }
+    }
+    return $totals;
 }
 
 function sff_admin_notice() {

--- a/wp-content/plugins/simplified-food-fitness/includes/meta-boxes.php
+++ b/wp-content/plugins/simplified-food-fitness/includes/meta-boxes.php
@@ -395,7 +395,10 @@ function sff_render_recipe_meta_box($post) {
     if (!is_array($saved)) {
         $saved = [];
     }
+
+    $servings = get_post_meta($post->ID, '_sff_recipe_servings', true);
     $ingredients = get_posts(['post_type' => 'ingredient', 'numberposts' => -1]);
+
     echo '<label><strong>Ingredients:</strong></label>';
     echo '<select name="sff_recipe_ingredients[]" multiple style="width:100%; height:150px;">';
     foreach ($ingredients as $ingredient) {
@@ -403,23 +406,51 @@ function sff_render_recipe_meta_box($post) {
         echo '<option value="' . esc_attr($ingredient->ID) . '" ' . $selected . '>' . esc_html($ingredient->post_title) . '</option>';
     }
     echo '</select>';
+
+    echo '<p><label><strong>Servings:</strong></label> <input type="number" name="sff_recipe_servings" value="' . esc_attr($servings) . '" min="1" style="width:80px;" /></p>';
+
+    $totals = get_post_meta($post->ID, '_sff_recipe_macros_total', true);
     $macros = get_post_meta($post->ID, '_sff_recipe_macros', true);
+
+    echo '<div id="sff-recipe-macro-display">';
     if (is_array($macros)) {
-        echo '<p><strong>Calories:</strong> ' . esc_html($macros['calories'] ?? 0) . '</p>';
-        echo '<p><strong>Carbs:</strong> ' . esc_html($macros['carbs'] ?? 0) . 'g</p>';
-        echo '<p><strong>Protein:</strong> ' . esc_html($macros['protein'] ?? 0) . 'g</p>';
-        echo '<p><strong>Fat:</strong> ' . esc_html($macros['fat'] ?? 0) . 'g</p>';
+        echo '<h4>Macros per serving</h4><ul class="per-serving">';
+        foreach (SFF_MACRO_FIELDS as $field) {
+            $label = ucwords(str_replace('_', ' ', $field));
+            $value = isset($macros[$field]) ? esc_html($macros[$field]) : 0;
+            echo '<li><strong>' . $label . ':</strong> ' . $value . '</li>';
+        }
+        echo '</ul>';
     }
+    if (is_array($totals)) {
+        echo '<h4>Total for recipe</h4><ul class="total">';
+        foreach (SFF_MACRO_FIELDS as $field) {
+            $label = ucwords(str_replace('_', ' ', $field));
+            $value = isset($totals[$field]) ? esc_html($totals[$field]) : 0;
+            echo '<li><strong>' . $label . ':</strong> ' . $value . '</li>';
+        }
+        echo '</ul>';
+    }
+    echo '</div>';
 }
 
 function sff_save_recipe_details($post_id) {
     if (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) return;
     if (!current_user_can('edit_post', $post_id)) return;
+    if (isset($_POST['sff_recipe_servings'])) {
+        update_post_meta($post_id, '_sff_recipe_servings', absint($_POST['sff_recipe_servings']));
+    }
     if (isset($_POST['sff_recipe_ingredients'])) {
         $ingredient_ids = array_map('intval', (array) $_POST['sff_recipe_ingredients']);
         update_post_meta($post_id, '_sff_recipe_ingredients', $ingredient_ids);
         $totals = sff_get_recipe_macros_from_ids($ingredient_ids);
-        update_post_meta($post_id, '_sff_recipe_macros', $totals);
+        update_post_meta($post_id, '_sff_recipe_macros_total', $totals);
+        $servings = max(1, intval(get_post_meta($post_id, '_sff_recipe_servings', true)));
+        $per_serving = [];
+        foreach ($totals as $key => $value) {
+            $per_serving[$key] = $value / $servings;
+        }
+        update_post_meta($post_id, '_sff_recipe_macros', $per_serving);
     }
 }
 add_action('save_post', 'sff_save_recipe_details');

--- a/wp-content/plugins/simplified-food-fitness/simplified-food-fitness.php
+++ b/wp-content/plugins/simplified-food-fitness/simplified-food-fitness.php
@@ -26,6 +26,11 @@ if (!defined('SFF_MACRO_FIELDS')) {
     ]);
 }
 
+if (!defined('SFF_USDA_API_KEY')) {
+    // Expect the USDA API key to be provided via environment variable to avoid committing secrets.
+    define('SFF_USDA_API_KEY', getenv('USDA_API_KEY') ?: '');
+}
+
 // Include all feature files
 require_once SFF_PLUGIN_DIR . 'includes/post-types.php';
 require_once SFF_PLUGIN_DIR . 'includes/meta-boxes.php';


### PR DESCRIPTION
## Summary
- aggregate full macro and micronutrient data from ingredient records
- show per-serving and total nutrients in recipe editor with live updates
- add AJAX endpoint and JS to recalc recipe nutrition when ingredients or servings change

## Testing
- `php -l wp-content/plugins/simplified-food-fitness/includes/helpers.php`
- `php -l wp-content/plugins/simplified-food-fitness/includes/meta-boxes.php`
- `php -l wp-content/plugins/simplified-food-fitness/includes/ajax.php`
- `php -l wp-content/plugins/simplified-food-fitness/includes/enqueue.php`


------
https://chatgpt.com/codex/tasks/task_e_68b0ae2fc8c483299f47aac87b7c9961