### PR TITLE
Add ingredient category taxonomy and filtering

### DIFF
--- a/wp-content/plugins/simplified-food-fitness/assets/js/sff-scripts.js
+++ b/wp-content/plugins/simplified-food-fitness/assets/js/sff-scripts.js
@@ -325,8 +325,9 @@ jQuery(document).ready(function($) {
 
   $('#sff-ingredient-search').on('keyup', function(){
     var q = $(this).val();
+    var cat = $('#sff-ingredient-category-filter').val();
     if (q.length < 2) { $('#sff-ingredient-results').empty(); return; }
-    $.get(sff_ajax_obj.ajax_url, {action:'sff_search_ingredients', security:sff_ajax_obj.nonce, q:q}, function(res){
+    $.get(sff_ajax_obj.ajax_url, {action:'sff_search_ingredients', security:sff_ajax_obj.nonce, q:q, category:cat}, function(res){
       if(res.success){
         var list = $('#sff-ingredient-results').empty();
         res.data.forEach(function(item){
@@ -335,6 +336,10 @@ jQuery(document).ready(function($) {
         });
       }
     });
+  });
+
+  $('#sff-ingredient-category-filter').on('change', function(){
+    $('#sff-ingredient-search').trigger('keyup');
   });
 
   $(document).on('click', '#sff-ingredient-results li', function(){

--- a/wp-content/plugins/simplified-food-fitness/includes/ajax.php
+++ b/wp-content/plugins/simplified-food-fitness/includes/ajax.php
@@ -888,11 +888,23 @@ function sff_search_ingredients() {
     }
 
     $term = isset($_GET['q']) ? sanitize_text_field(wp_unslash($_GET['q'])) : '';
-    $query = new WP_Query([
+    $tax_query = [];
+    if (!empty($_GET['category'])) {
+        $tax_query[] = [
+            'taxonomy' => 'ingredient_category',
+            'field' => 'term_id',
+            'terms' => intval($_GET['category']),
+        ];
+    }
+    $args = [
         'post_type' => 'ingredient',
         'posts_per_page' => 10,
         's' => $term,
-    ]);
+    ];
+    if ($tax_query) {
+        $args['tax_query'] = $tax_query;
+    }
+    $query = new WP_Query($args);
 
     $results = [];
     foreach ($query->posts as $post) {

--- a/wp-content/plugins/simplified-food-fitness/includes/helpers.php
+++ b/wp-content/plugins/simplified-food-fitness/includes/helpers.php
@@ -109,6 +109,7 @@ function sff_render_ingredient_form($post_id = null) {
     $fdc_id = '';
     $sku = $affiliate_link = '';
     $price = 0;
+    $ingredient_category = 0;
     $macros = [
         'calories' => 0, 'carbs' => 0, 'protein' => 0, 'fat' => 0, 
         'saturated_fat' => 0, 'trans_fat' => 0, 'cholesterol' => 0, 
@@ -129,6 +130,10 @@ function sff_render_ingredient_form($post_id = null) {
         $sku = get_post_meta($post_id, '_sff_sku', true);
         $affiliate_link = get_post_meta($post_id, '_sff_affiliate_link', true);
         $price = get_post_meta($post_id, '_sff_price', true);
+        $cat_terms = wp_get_post_terms($post_id, 'ingredient_category', ['fields' => 'ids']);
+        if (!empty($cat_terms)) {
+            $ingredient_category = $cat_terms[0];
+        }
     }
 
     ob_start(); ?>
@@ -173,6 +178,20 @@ function sff_render_ingredient_form($post_id = null) {
 
         <label style="font-size:14px; color:#777;">Product Name:</label>
         <input type="text" name="sff_brand_name" id="sff_product_name" value="<?php echo esc_attr($brand_name); ?>" placeholder="e.g., Brand X" style="width:100%; padding:10px; border:1px solid #ccc; border-radius:6px; margin-bottom:10px;">
+
+        <label style="font-size:14px; color:#777;">Category:</label>
+        <?php
+        $dropdown = wp_dropdown_categories([
+            'taxonomy' => 'ingredient_category',
+            'hide_empty' => false,
+            'name' => 'sff_ingredient_category',
+            'orderby' => 'name',
+            'selected' => $ingredient_category,
+            'show_option_none' => __('Select category'),
+            'echo' => false,
+        ]);
+        echo str_replace('<select', '<select style="width:100%; padding:10px; border:1px solid #ccc; border-radius:6px; margin-bottom:10px;"', $dropdown);
+        ?>
 
         <label style="font-size:14px; color:#777;">USDA FDC ID (optional):</label>
         <input type="text" name="sff_fdc_id" value="<?php echo esc_attr($fdc_id); ?>" placeholder="e.g., 123456" style="width:100%; padding:10px; border:1px solid #ccc; border-radius:6px; margin-bottom:10px;">
@@ -253,6 +272,15 @@ function sff_save_ingredient_details($post_id) {
 
     if (isset($_POST['sff_brand_name'])) {
         update_post_meta($post_id, '_sff_brand_name', sanitize_text_field($_POST['sff_brand_name']));
+    }
+
+    if (isset($_POST['sff_ingredient_category'])) {
+        $cat = intval($_POST['sff_ingredient_category']);
+        if ($cat) {
+            wp_set_object_terms($post_id, $cat, 'ingredient_category');
+        } else {
+            wp_set_object_terms($post_id, [], 'ingredient_category');
+        }
     }
 
     $fdc_id = '';

--- a/wp-content/plugins/simplified-food-fitness/includes/meta-boxes.php
+++ b/wp-content/plugins/simplified-food-fitness/includes/meta-boxes.php
@@ -183,6 +183,13 @@ function sff_render_meal_plan_meta_box($post) {
             <h3><?php esc_html_e('Create Recipe'); ?></h3>
 
             <input type="text" id="sff-recipe-name" placeholder="<?php esc_attr_e('Recipe Name'); ?>" style="width:100%; margin-bottom:8px;">
+            <?php $ingredient_categories = get_terms('ingredient_category', ['hide_empty' => false]); ?>
+            <select id="sff-ingredient-category-filter" style="width:100%; margin-bottom:8px;">
+                <option value=""><?php esc_html_e('All Categories'); ?></option>
+                <?php foreach ($ingredient_categories as $cat) : ?>
+                    <option value="<?php echo esc_attr($cat->term_id); ?>"><?php echo esc_html($cat->name); ?></option>
+                <?php endforeach; ?>
+            </select>
             <input type="text" id="sff-ingredient-search" placeholder="<?php esc_attr_e('Search ingredients'); ?>" style="width:100%; margin-bottom:8px;">
 
             <ul id="sff-ingredient-results" style="max-height:200px; overflow:auto; border:1px solid #eee; padding:8px; margin-bottom:8px;"></ul>

--- a/wp-content/plugins/simplified-food-fitness/includes/post-types.php
+++ b/wp-content/plugins/simplified-food-fitness/includes/post-types.php
@@ -76,7 +76,53 @@ function sff_register_custom_post_types() {
     'menu_position' => 6
 ]);
 
+    register_taxonomy('ingredient_category', ['ingredient'], [
+        'labels' => [
+            'name' => __('Ingredient Categories'),
+            'singular_name' => __('Ingredient Category')
+        ],
+        'public' => false,
+        'show_ui' => true,
+        'show_admin_column' => true,
+        'hierarchical' => true,
+    ]);
+
+    $default_terms = ['Meals', 'Vegetables', 'Fruits', 'Proteins', 'Grains'];
+    foreach ($default_terms as $term) {
+        if (!term_exists($term, 'ingredient_category')) {
+            wp_insert_term($term, 'ingredient_category');
+        }
+    }
+
 
 }
 add_action('init', 'sff_register_custom_post_types');
+
+function sff_ingredient_category_admin_filter() {
+    global $typenow;
+    if ($typenow === 'ingredient') {
+        $taxonomy = 'ingredient_category';
+        $selected = isset($_GET[$taxonomy]) ? $_GET[$taxonomy] : '';
+        wp_dropdown_categories([
+            'show_option_all' => __('All Categories'),
+            'taxonomy' => $taxonomy,
+            'name' => $taxonomy,
+            'orderby' => 'name',
+            'selected' => $selected,
+            'hierarchical' => true,
+            'hide_empty' => false,
+        ]);
+    }
+}
+add_action('restrict_manage_posts', 'sff_ingredient_category_admin_filter');
+
+function sff_ingredient_category_filter_query($query) {
+    global $pagenow;
+    $taxonomy = 'ingredient_category';
+    if ($pagenow === 'edit.php' && isset($_GET['post_type']) && $_GET['post_type'] === 'ingredient' && !empty($_GET[$taxonomy])) {
+        $term = intval($_GET[$taxonomy]);
+        $query->query_vars[$taxonomy] = $term;
+    }
+}
+add_filter('parse_query', 'sff_ingredient_category_filter_query');
 


### PR DESCRIPTION
## Summary
- Introduce `ingredient_category` taxonomy with default terms and attach to ingredients
- Allow selecting ingredient category in ingredient form and save taxonomy
- Enable filtering by ingredient category in admin UI and recipe ingredient selector

## Testing
- `php -l wp-content/plugins/simplified-food-fitness/includes/post-types.php`
- `php -l wp-content/plugins/simplified-food-fitness/includes/helpers.php`
- `php -l wp-content/plugins/simplified-food-fitness/includes/meta-boxes.php`
- `php -l wp-content/plugins/simplified-food-fitness/includes/ajax.php`


------
https://chatgpt.com/codex/tasks/task_e_68c1b108768c8329bc9cdc18f103c712