### PR TITLE
Add configurable USDA API key

### DIFF
--- a/wp-content/plugins/simplified-food-fitness/README.md
+++ b/wp-content/plugins/simplified-food-fitness/README.md
@@ -1,0 +1,14 @@
+# Simplified Food & Fitness
+
+## USDA API Key Configuration
+
+The plugin integrates with the [USDA FoodData Central API](https://fdc.nal.usda.gov/api-guide.html) for nutrition data.
+
+To configure the API key:
+
+1. Obtain an API key from the USDA website.
+2. In the WordPress admin dashboard, navigate to **Settings → Nutrition Label Settings**.
+3. Enter your key in the **USDA API Key** field and save.
+4. Alternatively, you can set an `USDA_API_KEY` environment variable which will override the saved option.
+
+The key is required for features that search nutrition data through the USDA service.

--- a/wp-content/plugins/simplified-food-fitness/includes/settings.php
+++ b/wp-content/plugins/simplified-food-fitness/includes/settings.php
@@ -17,7 +17,7 @@ add_action('admin_menu', 'sff_add_settings_menu');
 function sff_render_settings_page() {
    ?>
     <div class="wrap">
-        <h2>Google Vision API Settings</h2>
+        <h2>API Settings</h2>
         <form method="post" action="options.php">
             <?php
             settings_fields('sff_nutrition_settings');
@@ -31,14 +31,36 @@ function sff_render_settings_page() {
 
 function sff_register_settings() {
     register_setting('sff_nutrition_settings', 'sff_google_api_key');
+    register_setting('sff_nutrition_settings', 'sff_usda_api_key');
+
     add_settings_section('sff_api_settings_section', 'API Configuration', null, 'sff-nutrition-settings');
-    add_settings_field('sff_google_api_key', 'Google Cloud Vision API Key', 'sff_render_api_key_field', 'sff-nutrition-settings', 'sff_api_settings_section');
+
+    add_settings_field(
+        'sff_google_api_key',
+        'Google Cloud Vision API Key',
+        'sff_render_api_key_field',
+        'sff-nutrition-settings',
+        'sff_api_settings_section'
+    );
+
+    add_settings_field(
+        'sff_usda_api_key',
+        'USDA API Key',
+        'sff_render_usda_api_key_field',
+        'sff-nutrition-settings',
+        'sff_api_settings_section'
+    );
 }
 add_action('admin_init', 'sff_register_settings');
 
 function sff_render_api_key_field() {
     $api_key = get_option('sff_google_api_key', '');
     echo '<input type="text" name="sff_google_api_key" value="' . esc_attr($api_key) . '" style="width: 400px;">';
+}
+
+function sff_render_usda_api_key_field() {
+    $api_key = get_option('sff_usda_api_key', '');
+    echo '<input type="text" name="sff_usda_api_key" value="' . esc_attr($api_key) . '" style="width: 400px;">';
 }
 
 // function sff_client_leads_dashboard() {

--- a/wp-content/plugins/simplified-food-fitness/simplified-food-fitness.php
+++ b/wp-content/plugins/simplified-food-fitness/simplified-food-fitness.php
@@ -26,9 +26,16 @@ if (!defined('SFF_MACRO_FIELDS')) {
     ]);
 }
 
-if (!defined('SFF_USDA_API_KEY')) {
-    // Expect the USDA API key to be provided via environment variable to avoid committing secrets.
-    define('SFF_USDA_API_KEY', getenv('USDA_API_KEY') ?: '');
+// Define USDA API key, preferring environment variable with fallback to saved option.
+$env_usda_key = getenv('USDA_API_KEY');
+if ($env_usda_key) {
+    define('SFF_USDA_API_KEY', $env_usda_key);
+} else {
+    add_action('init', function () {
+        if (!defined('SFF_USDA_API_KEY')) {
+            define('SFF_USDA_API_KEY', get_option('sff_usda_api_key', ''));
+        }
+    });
 }
 
 // Include all feature files


### PR DESCRIPTION
## Summary
- allow storing a USDA API key in plugin settings with admin UI
- load USDA API key from environment or stored option on init
- document how to configure the USDA API key

## Testing
- `php -l wp-content/plugins/simplified-food-fitness/includes/settings.php`
- `php -l wp-content/plugins/simplified-food-fitness/simplified-food-fitness.php`


------
https://chatgpt.com/codex/tasks/task_e_68c1b39fff4083299f3b60bba4f9398f