### PR TITLE
feat: add USDA autocomplete

### DIFF
--- a/wp-content/plugins/simplified-food-fitness/assets/css/sff-styles.css
+++ b/wp-content/plugins/simplified-food-fitness/assets/css/sff-styles.css
@@ -184,6 +184,33 @@
     font-family: "Inter", sans-serif;
 }
 
+/* USDA Autocomplete Dropdown */
+#usda-suggestions {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    background: #fff;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    z-index: 1000;
+    max-height: 200px;
+    overflow-y: auto;
+}
+#usda-suggestions ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+#usda-suggestions li {
+    padding: 8px 10px;
+    cursor: pointer;
+}
+#usda-suggestions li:hover,
+#usda-suggestions li.active {
+    background: #E9FAB0;
+}
+
 .sff-profile-card h2 {
     margin-top: 0;
     font-size: 22px;

--- a/wp-content/plugins/simplified-food-fitness/assets/js/sff-scripts.js
+++ b/wp-content/plugins/simplified-food-fitness/assets/js/sff-scripts.js
@@ -389,23 +389,51 @@ jQuery(document).ready(function($) {
   toggleClientDayRequired('[name="client[]busy_days"]');
   toggleClientDayRequired('[name="client[]activity_days"]');
 
-  $('#sff-usda-search').on('click', function(){
-    var query = $('[name="sff_brand_name"]').val();
-    if(!query) return;
+  var usdaIndex = -1;
+
+  $('[name="sff_brand_name"]').on('keydown', function(e){
+    var items = $('#usda-suggestions li');
+    if(!items.length) return;
+    if(e.key === 'ArrowDown'){
+      e.preventDefault();
+      usdaIndex = (usdaIndex + 1) % items.length;
+      items.removeClass('active').eq(usdaIndex).addClass('active');
+    } else if(e.key === 'ArrowUp'){
+      e.preventDefault();
+      usdaIndex = (usdaIndex - 1 + items.length) % items.length;
+      items.removeClass('active').eq(usdaIndex).addClass('active');
+    } else if(e.key === 'Enter' && usdaIndex >= 0){
+      e.preventDefault();
+      items.eq(usdaIndex).trigger('click');
+    }
+  });
+
+  $('[name="sff_brand_name"]').on('keyup', function(e){
+    var ignored = ['ArrowDown','ArrowUp','Enter'];
+    if(ignored.includes(e.key)) return;
+    var query = $(this).val();
+    if(query.length < 3){
+      $('#usda-suggestions').hide().empty();
+      usdaIndex = -1;
+      return;
+    }
     $.post(sff_ajax_obj.ajax_url,{action:'sff_usda_search',security:sff_ajax_obj.nonce,query:query},function(res){
       if(res.success){
         var list = $('<ul/>');
         $.each(res.data,function(i,item){
-          list.append($('<li>').text(item.description).attr('data-fdc',item.fdc_id).css('cursor','pointer'));
+          list.append($('<li>').text(item.description).attr('data-fdc',item.fdc_id));
         });
-        $('#usda-search-results').html(list);
+        $('#usda-suggestions').html(list).show();
+        usdaIndex = -1;
       }
     });
   });
 
-  $('#usda-search-results').on('click','li',function(){
+  $('#usda-suggestions').on('click','li',function(){
     var fdc = $(this).data('fdc');
+    $('[name="sff_brand_name"]').val($(this).text());
     $('[name="sff_fdc_id"]').val(fdc);
+    $('#usda-suggestions').hide().empty();
     $.post(sff_ajax_obj.ajax_url,{action:'sff_usda_macros',security:sff_ajax_obj.nonce,fdc_id:fdc},function(res){
       if(res.success){
         $.each(res.data,function(k,v){

--- a/wp-content/plugins/simplified-food-fitness/includes/helpers.php
+++ b/wp-content/plugins/simplified-food-fitness/includes/helpers.php
@@ -155,10 +155,10 @@ function sff_render_ingredient_form($post_id = null) {
         <p style="font-size:14px; color:#777;">Scan a packaged item to grab its name, search the USDA database to load macros for fresh foods, or skip to type everything manually.</p>
 
         <label style="font-size:14px; color:#777;">Ingredient Name:</label>
-        <input type="text" name="sff_brand_name" id="sff_product_name" value="<?php echo esc_attr($brand_name); ?>" placeholder="e.g., Banana" style="width:100%; padding:10px; border:1px solid #ccc; border-radius:6px; margin-bottom:10px;">
-
-        <button type="button" id="sff-usda-search" style="margin-bottom:10px;" class="button">Search USDA</button>
-        <div id="usda-search-results" style="margin-bottom:10px;"></div>
+        <div style="position:relative;">
+            <input type="text" name="sff_brand_name" id="sff_product_name" value="<?php echo esc_attr($brand_name); ?>" placeholder="e.g., Banana" style="width:100%; padding:10px; border:1px solid #ccc; border-radius:6px; margin-bottom:10px;">
+            <div id="usda-suggestions" style="display:none;"></div>
+        </div>
 
         <?php if ($front_image) : ?>
             <img src="<?php echo esc_url($front_image); ?>" alt="Front Image" style="width:100px; height:auto; border-radius:8px; margin-bottom:10px;">


### PR DESCRIPTION
## Summary
- add AJAX-powered USDA ingredient autocomplete with keyboard navigation
- replace manual search results with inline suggestions container
- style USDA dropdown for clarity and hover highlighting

## Testing
- `npm test` *(fails: Could not read package.json)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1ca2e311c832989a73c89d87bd75e