### PR TITLE
Add USDA category filter to ingredient search

### DIFF
--- a/wp-content/plugins/simplified-food-fitness/assets/js/sff-scripts.js
+++ b/wp-content/plugins/simplified-food-fitness/assets/js/sff-scripts.js
@@ -408,25 +408,41 @@ jQuery(document).ready(function($) {
     }
   });
 
-  $('[name="sff_brand_name"]').on('keyup', function(e){
-    var ignored = ['ArrowDown','ArrowUp','Enter'];
-    if(ignored.includes(e.key)) return;
-    var query = $(this).val();
+  function usdaSearch(){
+    var query = $('[name="sff_brand_name"]').val();
+    var category = $('#usda-category-filter').val();
     if(query.length < 3){
       $('#usda-suggestions').hide().empty();
       usdaIndex = -1;
       return;
     }
-    $.post(sff_ajax_obj.ajax_url,{action:'sff_usda_search',security:sff_ajax_obj.nonce,query:query},function(res){
+    $.post(sff_ajax_obj.ajax_url,{action:'sff_usda_search',security:sff_ajax_obj.nonce,query:query,category:category},function(res){
       if(res.success){
         var list = $('<ul/>');
         $.each(res.data,function(i,item){
-          list.append($('<li>').text(item.description).attr('data-fdc',item.fdc_id));
+          if(!category || (item.foodCategory && item.foodCategory.toLowerCase().includes(category.toLowerCase())) || (item.dataType && item.dataType.toLowerCase().includes(category.toLowerCase()))){
+            list.append($('<li>').text(item.description).attr('data-fdc',item.fdc_id));
+          }
         });
-        $('#usda-suggestions').html(list).show();
+        if(list.children().length){
+          $('#usda-suggestions').html(list).show();
+        } else {
+          $('#usda-suggestions').hide().empty();
+        }
         usdaIndex = -1;
       }
     });
+  }
+
+  $('[name="sff_brand_name"]').on('keyup', function(e){
+    var ignored = ['ArrowDown','ArrowUp','Enter'];
+    if(ignored.includes(e.key)) return;
+    usdaSearch();
+  });
+
+  $('#usda-category-filter').on('change', function(){
+    $('[name="sff_fdc_id"]').val('');
+    usdaSearch();
   });
 
   $('#usda-suggestions').on('click','li',function(){

--- a/wp-content/plugins/simplified-food-fitness/includes/ajax.php
+++ b/wp-content/plugins/simplified-food-fitness/includes/ajax.php
@@ -490,10 +490,14 @@ function sff_save_client_intake() {
 function sff_usda_search() {
     check_ajax_referer('sff_scan_nonce', 'security');
     $query = sanitize_text_field($_POST['query'] ?? '');
+    $category = sanitize_text_field($_POST['category'] ?? '');
     if (!$query || !SFF_USDA_API_KEY) {
         wp_send_json_error('Missing query');
     }
     $url = 'https://api.nal.usda.gov/fdc/v1/foods/search?api_key=' . urlencode(SFF_USDA_API_KEY) . '&query=' . urlencode($query) . '&pageSize=5';
+    if ($category) {
+        $url .= '&foodCategory=' . urlencode($category);
+    }
     $resp = wp_remote_get($url);
     if (is_wp_error($resp)) {
         wp_send_json_error('API error');
@@ -502,7 +506,12 @@ function sff_usda_search() {
     $items = [];
     if (!empty($body['foods'])) {
         foreach ($body['foods'] as $food) {
-            $items[] = ['fdc_id' => $food['fdcId'], 'description' => $food['description']];
+            $items[] = [
+                'fdc_id' => $food['fdcId'],
+                'description' => $food['description'],
+                'dataType' => $food['dataType'] ?? '',
+                'foodCategory' => $food['foodCategory'] ?? ''
+            ];
         }
     }
     wp_send_json_success($items);

--- a/wp-content/plugins/simplified-food-fitness/includes/helpers.php
+++ b/wp-content/plugins/simplified-food-fitness/includes/helpers.php
@@ -157,6 +157,12 @@ function sff_render_ingredient_form($post_id = null) {
         <label style="font-size:14px; color:#777;">Ingredient Name:</label>
         <div style="position:relative;">
             <input type="text" name="sff_brand_name" id="sff_product_name" value="<?php echo esc_attr($brand_name); ?>" placeholder="e.g., Banana" style="width:100%; padding:10px; border:1px solid #ccc; border-radius:6px; margin-bottom:10px;">
+            <select id="usda-category-filter" style="width:100%; padding:10px; border:1px solid #ccc; border-radius:6px; margin-bottom:10px;">
+                <option value="">All Categories</option>
+                <option value="Fruits">Fruits</option>
+                <option value="Vegetables">Vegetables</option>
+                <option value="Grains">Grains</option>
+            </select>
             <div id="usda-suggestions" style="display:none;"></div>
         </div>
 


### PR DESCRIPTION
## Summary
- add dropdown to filter USDA categories when searching ingredients
- forward category to AJAX search and include category info in results
- filter suggestions client-side and reload results on category change

## Testing
- `php -l wp-content/plugins/simplified-food-fitness/includes/helpers.php`
- `php -l wp-content/plugins/simplified-food-fitness/includes/ajax.php`
- `node --check wp-content/plugins/simplified-food-fitness/assets/js/sff-scripts.js`


------
https://chatgpt.com/codex/tasks/task_e_68c1cd6196d08329bcaf4346ff208ede