### PR TITLE
Restore USDA search button and conditional macro workflow

### DIFF
--- a/wp-content/plugins/simplified-food-fitness/assets/css/sff-styles.css
+++ b/wp-content/plugins/simplified-food-fitness/assets/css/sff-styles.css
@@ -211,6 +211,22 @@
     background: #E9FAB0;
 }
 
+.sff-option {
+    margin-bottom: 20px;
+}
+
+.sff-divider {
+    text-align: center;
+    margin: 15px 0;
+    font-weight: 600;
+    color: #777;
+}
+
+.sff-divider span {
+    background: #fff;
+    padding: 0 10px;
+}
+
 .sff-profile-card h2 {
     margin-top: 0;
     font-size: 22px;

--- a/wp-content/plugins/simplified-food-fitness/assets/js/sff-scripts.js
+++ b/wp-content/plugins/simplified-food-fitness/assets/js/sff-scripts.js
@@ -3,10 +3,34 @@ jQuery(document).ready(function($) {
         // Product Name Scan Handler
   
 
-    // Ensure wizard moves to Step 2 and retains scanned data
+    // Move to Step 2 and determine macro workflow
     $('#next_step_button').on('click', function() {
         $('#sff-wizard-step-1').hide();
         $('#sff-wizard-step-2').show();
+
+        var fdc = $('#sff_fdc_id').val();
+        var fromPicture = $('#front_image_attachment_id').length > 0;
+
+        if (fdc) {
+            // Hide scan option and fetch macros from USDA
+            $('#sff_nutrition_label_upload, #scan_nutrition_label_button, #scan_results').hide();
+            $.post(sff_ajax_obj.ajax_url, {action:'sff_usda_macros', security:sff_ajax_obj.nonce, fdc_id:fdc}, function(res){
+                if(res.success){
+                    $.each(res.data, function(k,v){
+                        $('[name="sff_macros['+k+']"]').val(v);
+                    });
+                    $('#sff_macro_source').val('usda');
+                    $('#macro_source_text').text('USDA');
+                }
+            });
+        } else {
+            // Show scan option only if product image provided
+            if(fromPicture){
+                $('#sff_nutrition_label_upload, #scan_nutrition_label_button, #scan_results').show();
+            } else {
+                $('#sff_nutrition_label_upload, #scan_nutrition_label_button, #scan_results').hide();
+            }
+        }
     });
 
     $('#scan_front_image_button').on('click', function() {
@@ -411,7 +435,7 @@ jQuery(document).ready(function($) {
   function usdaSearch(){
     var query = $('[name="sff_brand_name"]').val();
     var category = $('#usda-category-filter').val();
-    if(query.length < 3){
+    if(query.length < 1){
       $('#usda-suggestions').hide().empty();
       usdaIndex = -1;
       return;
@@ -430,19 +454,19 @@ jQuery(document).ready(function($) {
           $('#usda-suggestions').hide().empty();
         }
         usdaIndex = -1;
+      } else {
+        $('#usda-suggestions').hide().empty();
       }
     });
   }
 
-  $('[name="sff_brand_name"]').on('keyup', function(e){
-    var ignored = ['ArrowDown','ArrowUp','Enter'];
-    if(ignored.includes(e.key)) return;
+  $('#usda-search-button').on('click', function(){
+    $('[name="sff_fdc_id"]').val('');
     usdaSearch();
   });
 
   $('#usda-category-filter').on('change', function(){
-    $('[name="sff_fdc_id"]').val('');
-    usdaSearch();
+    $('#usda-search-button').trigger('click');
   });
 
   $('#usda-suggestions').on('click','li',function(){
@@ -450,15 +474,6 @@ jQuery(document).ready(function($) {
     $('[name="sff_brand_name"]').val($(this).text());
     $('[name="sff_fdc_id"]').val(fdc);
     $('#usda-suggestions').hide().empty();
-    $.post(sff_ajax_obj.ajax_url,{action:'sff_usda_macros',security:sff_ajax_obj.nonce,fdc_id:fdc},function(res){
-      if(res.success){
-        $.each(res.data,function(k,v){
-          $('[name="sff_macros['+k+']"]').val(v);
-        });
-        $('#sff_macro_source').val('usda');
-        $('#macro_source_text').text('USDA');
-      }
-    });
   });
 
   $('#sff-wizard-step-2').on('input','[name^="sff_macros"]',function(){

--- a/wp-content/plugins/simplified-food-fitness/includes/ajax.php
+++ b/wp-content/plugins/simplified-food-fitness/includes/ajax.php
@@ -494,7 +494,7 @@ function sff_usda_search() {
     if (!$query || !SFF_USDA_API_KEY) {
         wp_send_json_error('Missing query');
     }
-    $url = 'https://api.nal.usda.gov/fdc/v1/foods/search?api_key=' . urlencode(SFF_USDA_API_KEY) . '&query=' . urlencode($query) . '&pageSize=5';
+    $url = 'https://api.nal.usda.gov/fdc/v1/foods/search?api_key=' . urlencode(SFF_USDA_API_KEY) . '&query=' . urlencode($query) . '&pageSize=50';
     if ($category) {
         $url .= '&foodCategory=' . urlencode($category);
     }

--- a/wp-content/plugins/simplified-food-fitness/includes/helpers.php
+++ b/wp-content/plugins/simplified-food-fitness/includes/helpers.php
@@ -152,29 +152,37 @@ function sff_render_ingredient_form($post_id = null) {
 
     <div id="sff-wizard-step-1">
         <h3 style="font-size:18px; color:#333; margin-bottom:10px;">Step 1: Find Ingredient</h3>
-        <p style="font-size:14px; color:#777;">Scan a packaged item to grab its name, search the USDA database to load macros for fresh foods, or skip to type everything manually.</p>
+        <p style="font-size:14px; color:#777;">Choose a source below to begin.</p>
 
-        <label style="font-size:14px; color:#777;">Ingredient Name:</label>
-        <div style="position:relative;">
-            <input type="text" name="sff_brand_name" id="sff_product_name" value="<?php echo esc_attr($brand_name); ?>" placeholder="e.g., Banana" style="width:100%; padding:10px; border:1px solid #ccc; border-radius:6px; margin-bottom:10px;">
-            <select id="usda-category-filter" style="width:100%; padding:10px; border:1px solid #ccc; border-radius:6px; margin-bottom:10px;">
-                <option value="">All Categories</option>
-                <option value="Fruits">Fruits</option>
-                <option value="Vegetables">Vegetables</option>
-                <option value="Grains">Grains</option>
-            </select>
-            <div id="usda-suggestions" style="display:none;"></div>
+        <div class="sff-option">
+            <h4 style="font-size:16px; color:#333; margin-bottom:8px;">Option 1: Search USDA Database</h4>
+            <div style="position:relative;">
+                <input type="text" name="sff_brand_name" id="sff_product_name" value="<?php echo esc_attr($brand_name); ?>" placeholder="Start typing e.g., Banana" style="width:100%; padding:10px; border:1px solid #ccc; border-radius:6px; margin-bottom:10px;">
+                <select id="usda-category-filter" style="width:100%; padding:10px; border:1px solid #ccc; border-radius:6px; margin-bottom:10px;">
+                    <option value="">All Categories</option>
+                    <option value="Fruits">Fruits</option>
+                    <option value="Vegetables">Vegetables</option>
+                    <option value="Grains">Grains</option>
+                </select>
+                <button type="button" id="usda-search-button" style="background:#42b14c; color:white; border:none; padding:10px; border-radius:6px; cursor:pointer; font-size:14px; width:100%; margin-bottom:10px;">Search USDA</button>
+                <div id="usda-suggestions" style="display:none;"></div>
+            </div>
         </div>
 
-        <?php if ($front_image) : ?>
-            <img src="<?php echo esc_url($front_image); ?>" alt="Front Image" style="width:100px; height:auto; border-radius:8px; margin-bottom:10px;">
-        <?php endif; ?>
+        <div class="sff-divider"><span>OR</span></div>
 
-        <input type="file" id="sff_front_image_upload" accept="image/*" style="width:100%; padding:10px; border:1px solid #ccc; border-radius:6px;">
-        <button type="button" id="scan_front_image_button" style="background:#42b14c; color:white; border:none; padding:10px; border-radius:6px; cursor:pointer; font-size:14px; width:100%; margin-top:10px;">
-            1️⃣ Scan Product Name
-        </button>
-        <div id="scan_front_results" style="margin-top:10px; padding:10px; background:#f8f8f8; border-radius:8px; font-size:0.9rem; text-align:center;"></div>
+        <div class="sff-option">
+            <h4 style="font-size:16px; color:#333; margin-bottom:8px;">Option 2: Upload Product Label</h4>
+            <?php if ($front_image) : ?>
+                <img src="<?php echo esc_url($front_image); ?>" alt="Front Image" style="width:100px; height:auto; border-radius:8px; margin-bottom:10px;">
+            <?php endif; ?>
+
+            <input type="file" id="sff_front_image_upload" accept="image/*" style="width:100%; padding:10px; border:1px solid #ccc; border-radius:6px;">
+            <button type="button" id="scan_front_image_button" style="background:#42b14c; color:white; border:none; padding:10px; border-radius:6px; cursor:pointer; font-size:14px; width:100%; margin-top:10px;">
+                1️⃣ Scan Product Name
+            </button>
+            <div id="scan_front_results" style="margin-top:10px; padding:10px; background:#f8f8f8; border-radius:8px; font-size:0.9rem; text-align:center;"></div>
+        </div>
 
         <button type="button" id="next_step_button" style="background:#E9FAB0; color:#023441; border:none; padding:12px; border-radius:8px; cursor:pointer; font-size:16px; width:100%; margin-top:20px;">
             Next Step →


### PR DESCRIPTION
## Summary
- Add explicit USDA search button and return up to 50 results for selection
- Only fetch USDA macros after advancing, and hide scan fields unless a product image was used
- Wire search button and category filter for clearer ingredient selection

## Testing
- `php -l wp-content/plugins/simplified-food-fitness/includes/helpers.php`
- `php -l wp-content/plugins/simplified-food-fitness/includes/ajax.php`
- `node --check wp-content/plugins/simplified-food-fitness/assets/js/sff-scripts.js`


------
https://chatgpt.com/codex/tasks/task_e_68c1d11db86483299dcb62886eb483d8