### PR TITLE
Add USDA search button and delay macro fetch

### DIFF
--- a/wp-content/plugins/simplified-food-fitness/assets/js/sff-scripts.js
+++ b/wp-content/plugins/simplified-food-fitness/assets/js/sff-scripts.js
@@ -436,18 +436,21 @@ jQuery(document).ready(function($) {
     });
   }
 
-  $('[name="sff_brand_name"]').on('keyup', function(e){
-    var ignored = ['ArrowDown','ArrowUp','Enter'];
-    if(ignored.includes(e.key)) return;
+  $('#usda-search-button').on('click', function(){
     usdaSearch();
   });
-
-  $('#usda-category-filter').on('change', function(){
+  $('[name="sff_brand_name"]').on('keypress', function(e){
+    if(e.key === 'Enter'){
+      e.preventDefault();
+      usdaSearch();
+    }
+  });
+  $('#usda-category-filter').off('change').on('change', function(){
     $('[name="sff_fdc_id"]').val('');
     usdaSearch();
   });
 
-  $('#usda-suggestions').on('click','li',function(){
+    $  $('#usda-suggestions').on('click','li',function(){
     var fdc = $(this).data('fdc');
     $('[name="sff_brand_name"]').val($(this).text());
     $('[name="sff_fdc_id"]').val(fdc);
@@ -470,3 +473,46 @@ jQuery(document).ready(function($) {
 });
 
 
+jQuery(document).ready(function($){
+  $('#usda-search-button').on('click', function(){
+    usdaSearch();
+  });
+  $('[name="sff_brand_name"]').on('keypress', function(e){
+    if(e.key === 'Enter'){
+      e.preventDefault();
+      usdaSearch();
+    }
+  });
+  $('#usda-suggestions').off('click').on('click','li',function(){
+    var fdc = $(this).data('fdc');
+    $('[name="sff_brand_name"]').val($(this).text());
+    $('[name="sff_fdc_id"]').val(fdc);
+    $('#usda-suggestions').hide().empty();
+  });
+  $('#next_step_button').off('click').on('click', function(){
+    $('#sff-wizard-step-1').hide();
+    $('#sff-wizard-step-2').show();
+    var hasImage = $('#front_image_attachment_id').val() || ($('#sff_front_image_upload')[0] && $('#sff_front_image_upload')[0].files.length > 0);
+    if(!hasImage){
+      $('#sff_scan_fields').hide();
+    } else {
+      $('#sff_scan_fields').show();
+    }
+    var fdc = $('#sff_fdc_id').val();
+    if(fdc){
+      $.post(sff_ajax_obj.ajax_url,{action:'sff_usda_macros',security:sff_ajax_obj.nonce,fdc_id:fdc},function(res){
+        if(res.success){
+          $.each(res.data,function(k,v){
+            $('[name="sff_macros['+k+']"]').val(v);
+          });
+          $('#sff_macro_source').val('usda');
+          $('#macro_source_text').text('USDA');
+        }
+      });
+    }
+  });
+  $('#usda-category-filter').off('change').on('change', function(){
+    $('[name="sff_fdc_id"]').val('');
+    usdaSearch();
+  });
+});

--- a/wp-content/plugins/simplified-food-fitness/includes/ajax.php
+++ b/wp-content/plugins/simplified-food-fitness/includes/ajax.php
@@ -494,7 +494,7 @@ function sff_usda_search() {
     if (!$query || !SFF_USDA_API_KEY) {
         wp_send_json_error('Missing query');
     }
-    $url = 'https://api.nal.usda.gov/fdc/v1/foods/search?api_key=' . urlencode(SFF_USDA_API_KEY) . '&query=' . urlencode($query) . '&pageSize=5';
+    $url = 'https://api.nal.usda.gov/fdc/v1/foods/search?api_key=' . urlencode(SFF_USDA_API_KEY) . '&query=' . urlencode($query) . '&pageSize=50';
     if ($category) {
         $url .= '&foodCategory=' . urlencode($category);
     }

--- a/wp-content/plugins/simplified-food-fitness/includes/helpers.php
+++ b/wp-content/plugins/simplified-food-fitness/includes/helpers.php
@@ -164,6 +164,7 @@ function sff_render_ingredient_form($post_id = null) {
                     <option value="Vegetables">Vegetables</option>
                     <option value="Grains">Grains</option>
                 </select>
+                <button type="button" id="usda-search-button" style="background:#42b14c; color:white; border:none; padding:10px; border-radius:6px; cursor:pointer; font-size:14px; width:100%; margin-bottom:10px;">🔍 Search</button>
                 <div id="usda-suggestions" style="display:none;"></div>
             </div>
         </div>
@@ -213,11 +214,13 @@ function sff_render_ingredient_form($post_id = null) {
         echo str_replace('<select', '<select style="width:100%; padding:10px; border:1px solid #ccc; border-radius:6px; margin-bottom:10px;"', $dropdown);
         ?>
 
-        <input type="file" id="sff_nutrition_label_upload" accept="image/*" style="width:100%; padding:10px; border:1px solid #ccc; border-radius:6px;">
-        <button type="button" id="scan_nutrition_label_button" style="background:#42b14c; color:white; border:none; padding:10px; border-radius:6px; cursor:pointer; font-size:14px; width:100%; margin-top:10px;">
-            2️⃣ Scan Nutrition Label 🥗
-        </button>
-        <div id="scan_results" style="margin-top:10px; padding:10px; background:#f8f8f8; border-radius:8px; font-size:0.9rem; text-align:center;"></div>
+        <div id="sff_scan_fields">
+            <input type="file" id="sff_nutrition_label_upload" accept="image/*" style="width:100%; padding:10px; border:1px solid #ccc; border-radius:6px;">
+            <button type="button" id="scan_nutrition_label_button" style="background:#42b14c; color:white; border:none; padding:10px; border-radius:6px; cursor:pointer; font-size:14px; width:100%; margin-top:10px;">
+                2️⃣ Scan Nutrition Label 🥗
+            </button>
+            <div id="scan_results" style="margin-top:10px; padding:10px; background:#f8f8f8; border-radius:8px; font-size:0.9rem; text-align:center;"></div>
+        </div>
 
         <p style="font-size:14px; color:#777;">Macros source: <span id="macro_source_text"><?php echo ucfirst($macro_source); ?></span></p>
         <input type="hidden" name="sff_macro_source" id="sff_macro_source" value="<?php echo esc_attr($macro_source); ?>">


### PR DESCRIPTION
## Summary
- add dedicated USDA search button and category filter
- return up to 50 USDA results and load macros after advancing
- hide nutrition label scan fields unless a product image is provided

## Testing
- `php -l wp-content/plugins/simplified-food-fitness/includes/ajax.php` *(fails: No such file or directory)*
- `node --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d663f3f0832997d81faf691e4cdb