### PR TITLE
Fix USDA search by consolidating JS

### DIFF
--- a/wp-content/plugins/simplified-food-fitness/assets/js/sff-scripts.js
+++ b/wp-content/plugins/simplified-food-fitness/assets/js/sff-scripts.js
@@ -7,6 +7,32 @@ jQuery(document).ready(function($) {
     $('#next_step_button').on('click', function() {
         $('#sff-wizard-step-1').hide();
         $('#sff-wizard-step-2').show();
+
+        var hasImage = $('#front_image_attachment_id').val() ||
+            ($('#sff_front_image_upload')[0] && $('#sff_front_image_upload')[0].files.length > 0);
+
+        if (!hasImage) {
+            $('#sff_scan_fields').hide();
+        } else {
+            $('#sff_scan_fields').show();
+        }
+
+        var fdc = $('#sff_fdc_id').val();
+        if (fdc) {
+            $.post(
+                sff_ajax_obj.ajax_url,
+                { action: 'sff_usda_macros', security: sff_ajax_obj.nonce, fdc_id: fdc },
+                function(res) {
+                    if (res.success) {
+                        $.each(res.data, function(k, v) {
+                            $('[name="sff_macros[' + k + ']"]').val(v);
+                        });
+                        $('#sff_macro_source').val('usda');
+                        $('#macro_source_text').text('USDA');
+                    }
+                }
+            );
+        }
     });
 
     $('#scan_front_image_button').on('click', function() {
@@ -450,7 +476,7 @@ jQuery(document).ready(function($) {
     usdaSearch();
   });
 
-    $  $('#usda-suggestions').on('click','li',function(){
+    $('#usda-suggestions').on('click','li',function(){
     var fdc = $(this).data('fdc');
     $('[name="sff_brand_name"]').val($(this).text());
     $('[name="sff_fdc_id"]').val(fdc);
@@ -470,49 +496,4 @@ jQuery(document).ready(function($) {
     $('#sff_macro_source').val('manual');
     $('#macro_source_text').text('Manual');
   });
-});
-
-
-jQuery(document).ready(function($){
-  $('#usda-search-button').on('click', function(){
-    usdaSearch();
   });
-  $('[name="sff_brand_name"]').on('keypress', function(e){
-    if(e.key === 'Enter'){
-      e.preventDefault();
-      usdaSearch();
-    }
-  });
-  $('#usda-suggestions').off('click').on('click','li',function(){
-    var fdc = $(this).data('fdc');
-    $('[name="sff_brand_name"]').val($(this).text());
-    $('[name="sff_fdc_id"]').val(fdc);
-    $('#usda-suggestions').hide().empty();
-  });
-  $('#next_step_button').off('click').on('click', function(){
-    $('#sff-wizard-step-1').hide();
-    $('#sff-wizard-step-2').show();
-    var hasImage = $('#front_image_attachment_id').val() || ($('#sff_front_image_upload')[0] && $('#sff_front_image_upload')[0].files.length > 0);
-    if(!hasImage){
-      $('#sff_scan_fields').hide();
-    } else {
-      $('#sff_scan_fields').show();
-    }
-    var fdc = $('#sff_fdc_id').val();
-    if(fdc){
-      $.post(sff_ajax_obj.ajax_url,{action:'sff_usda_macros',security:sff_ajax_obj.nonce,fdc_id:fdc},function(res){
-        if(res.success){
-          $.each(res.data,function(k,v){
-            $('[name="sff_macros['+k+']"]').val(v);
-          });
-          $('#sff_macro_source').val('usda');
-          $('#macro_source_text').text('USDA');
-        }
-      });
-    }
-  });
-  $('#usda-category-filter').off('change').on('change', function(){
-    $('[name="sff_fdc_id"]').val('');
-    usdaSearch();
-  });
-});


### PR DESCRIPTION
## Summary
- ensure "Next Step" button toggles scan fields and preloads macros
- consolidate USDA search handlers into a single jQuery ready block

## Testing
- `node --check wp-content/plugins/simplified-food-fitness/assets/js/sff-scripts.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d959e5388329952e4309894931ae