### PR TITLE
Pre-fill ingredient category from USDA filter

### DIFF
--- a/wp-content/plugins/simplified-food-fitness/assets/js/sff-scripts.js
+++ b/wp-content/plugins/simplified-food-fitness/assets/js/sff-scripts.js
@@ -17,7 +17,20 @@ jQuery(document).ready(function($) {
             $('#sff_scan_fields').show();
         }
 
+        // Set the Step 2 category from the USDA filter
+        var categorySelect = $('select[name="sff_ingredient_category"]');
+        var usdaCategory = $('#usda-category-filter').val();
+        if (categorySelect.length && usdaCategory) {
+            categorySelect.val(usdaCategory);
+        }
+
         var fdc = $('#sff_fdc_id').val();
+        if (fdc && categorySelect.length) {
+            // Hide/disable category selection when a USDA match is used
+            categorySelect.prop('disabled', true).hide();
+            categorySelect.prev('label').hide();
+        }
+
         if (fdc) {
             $.post(
                 sff_ajax_obj.ajax_url,
@@ -32,6 +45,10 @@ jQuery(document).ready(function($) {
                     }
                 }
             );
+        } else if (categorySelect.length) {
+            // Ensure category dropdown is visible if no USDA match
+            categorySelect.prop('disabled', false).show();
+            categorySelect.prev('label').show();
         }
     });
 

--- a/wp-content/plugins/simplified-food-fitness/includes/helpers.php
+++ b/wp-content/plugins/simplified-food-fitness/includes/helpers.php
@@ -200,18 +200,23 @@ function sff_render_ingredient_form($post_id = null) {
 
         <input type="hidden" name="sff_fdc_id" id="sff_fdc_id" value="<?php echo esc_attr($fdc_id); ?>">
 
-        <label style="font-size:14px; color:#777;">Category:</label>
         <?php
-        $dropdown = wp_dropdown_categories([
-            'taxonomy' => 'ingredient_category',
-            'hide_empty' => false,
-            'name' => 'sff_ingredient_category',
-            'orderby' => 'name',
-            'selected' => $ingredient_category,
-            'show_option_none' => __('Select category'),
-            'echo' => false,
-        ]);
-        echo str_replace('<select', '<select style="width:100%; padding:10px; border:1px solid #ccc; border-radius:6px; margin-bottom:10px;"', $dropdown);
+        $show_category_dropdown = apply_filters('sff_show_category_dropdown', empty($fdc_id));
+        if ($show_category_dropdown) :
+            ?>
+            <label style="font-size:14px; color:#777;">Category:</label>
+            <?php
+            $dropdown = wp_dropdown_categories([
+                'taxonomy' => 'ingredient_category',
+                'hide_empty' => false,
+                'name' => 'sff_ingredient_category',
+                'orderby' => 'name',
+                'selected' => $ingredient_category,
+                'show_option_none' => __('Select category'),
+                'echo' => false,
+            ]);
+            echo str_replace('<select', '<select style="width:100%; padding:10px; border:1px solid #ccc; border-radius:6px; margin-bottom:10px;"', $dropdown);
+        endif;
         ?>
 
         <div id="sff_scan_fields">


### PR DESCRIPTION
## Summary
- Auto-fill Step 2 ingredient category based on the USDA filter selection
- Hide or disable category dropdown when a USDA `fdc_id` is used
- Render category field only when no `fdc_id` exists

## Testing
- `php -l wp-content/plugins/simplified-food-fitness/includes/helpers.php`
- `node --check wp-content/plugins/simplified-food-fitness/assets/js/sff-scripts.js`

------
https://chatgpt.com/codex/tasks/task_e_68c1e081bc748329b33878ecab9070b8