### PR TITLE
Expand USDA macro mapping and auto-populate fields

### DIFF
--- a/wp-content/plugins/simplified-food-fitness/assets/js/sff-scripts.js
+++ b/wp-content/plugins/simplified-food-fitness/assets/js/sff-scripts.js
@@ -1,4 +1,10 @@
 jQuery(document).ready(function($) {
+    function sffPopulateMacros(map) {
+        $.each(map, function(k, v) {
+            $('[name="sff_macros[' + k + ']"]').val(v);
+        });
+    }
+
 
         // Product Name Scan Handler
   
@@ -37,9 +43,7 @@ jQuery(document).ready(function($) {
                 { action: 'sff_usda_macros', security: sff_ajax_obj.nonce, fdc_id: fdc },
                 function(res) {
                     if (res.success) {
-                        $.each(res.data, function(k, v) {
-                            $('[name="sff_macros[' + k + ']"]').val(v);
-                        });
+                        sffPopulateMacros(res.data);
                         $('#sff_macro_source').val('usda');
                         $('#macro_source_text').text('USDA');
                     }
@@ -500,9 +504,7 @@ jQuery(document).ready(function($) {
     $('#usda-suggestions').hide().empty();
     $.post(sff_ajax_obj.ajax_url,{action:'sff_usda_macros',security:sff_ajax_obj.nonce,fdc_id:fdc},function(res){
       if(res.success){
-        $.each(res.data,function(k,v){
-          $('[name="sff_macros['+k+']"]').val(v);
-        });
+        sffPopulateMacros(res.data);
         $('#sff_macro_source').val('usda');
         $('#macro_source_text').text('USDA');
       }

--- a/wp-content/plugins/simplified-food-fitness/includes/ajax.php
+++ b/wp-content/plugins/simplified-food-fitness/includes/ajax.php
@@ -525,6 +525,7 @@ function sff_usda_macros() {
         wp_send_json_error('Missing FDC ID');
     }
     $macros = sff_fetch_usda_macros($fdc_id);
+    $macros = array_intersect_key($macros, array_flip(SFF_MACRO_FIELDS));
     if (!$macros) {
         wp_send_json_error('Not found');
     }

--- a/wp-content/plugins/simplified-food-fitness/includes/helpers.php
+++ b/wp-content/plugins/simplified-food-fitness/includes/helpers.php
@@ -79,29 +79,45 @@ function sff_fetch_usda_macros($fdc_id) {
         return [];
     }
 
-    $macros = ['calories' => 0, 'carbs' => 0, 'protein' => 0, 'fat' => 0];
+    $map = [
+        'Energy' => 'calories',
+        'Carbohydrate, by difference' => 'carbs',
+        'Protein' => 'protein',
+        'Total lipid (fat)' => 'fat',
+        'Fatty acids, total saturated' => 'saturated_fat',
+        'Fatty acids, total trans' => 'trans_fat',
+        'Cholesterol' => 'cholesterol',
+        'Sodium, Na' => 'sodium',
+        'Fiber, total dietary' => 'fiber',
+        'Sugars, total including NLEA' => 'sugars',
+        'Sugars, added' => 'added_sugars',
+        'Vitamin D (D2 + D3)' => 'vitamin_d',
+        'Calcium, Ca' => 'calcium',
+        'Iron, Fe' => 'iron',
+        'Potassium, K' => 'potassium',
+        'Magnesium, Mg' => 'magnesium',
+        'Vitamin A, RAE' => 'vitamin_a',
+        'Vitamin C, total ascorbic acid' => 'vitamin_c',
+        'Vitamin E (alpha-tocopherol)' => 'vitamin_e',
+        'Zinc, Zn' => 'zinc',
+        'Folate, total' => 'folate',
+        'Riboflavin' => 'riboflavin',
+        'Niacin' => 'niacin',
+        'Vitamin B-6' => 'vitamin_b6',
+        'Vitamin B-12' => 'vitamin_b12',
+        'Thiamin' => 'thiamin',
+    ];
+
+    $macros = array_fill_keys(array_values($map), 0);
     foreach ($data['foodNutrients'] as $nutrient) {
         $name  = $nutrient['nutrientName'] ?? '';
-        $value = isset($nutrient['value']) ? floatval($nutrient['value']) : 0;
-        switch ($name) {
-            case 'Energy':
-                $macros['calories'] = $value;
-                break;
-            case 'Carbohydrate, by difference':
-                $macros['carbs'] = $value;
-                break;
-            case 'Protein':
-                $macros['protein'] = $value;
-                break;
-            case 'Total lipid (fat)':
-                $macros['fat'] = $value;
-                break;
+        if (isset($map[$name])) {
+            $macros[$map[$name]] = isset($nutrient['value']) ? floatval($nutrient['value']) : 0;
         }
     }
 
     return $macros;
 }
-
 function sff_render_ingredient_form($post_id = null) {
    // Get existing ingredient data if editing
     $brand_name = $serving_size = $servings = '';


### PR DESCRIPTION
## Summary
- map additional USDA nutrient names to plugin macro keys
- return full macro set from `sff_usda_macros`
- dynamically populate matching macro inputs on step 2

## Testing
- `php -l includes/helpers.php` *(fails: command not found)*
- `php -l includes/ajax.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e2834e248329904509399aecd21e