### PR TITLE
feat: show USDA nutrition preview

### DIFF
--- a/wp-content/plugins/simplified-food-fitness/assets/js/sff-scripts.js
+++ b/wp-content/plugins/simplified-food-fitness/assets/js/sff-scripts.js
@@ -1,8 +1,20 @@
 jQuery(document).ready(function($) {
+    function sffShowMacroPreview(map) {
+        var html = '<strong>Fetched Macros:</strong><ul>';
+        $.each(map, function(k, v) {
+            if ($('[name="sff_macros[' + k + ']"]').length) {
+                html += '<li>' + k.replace(/_/g, ' ') + ': ' + v + '</li>';
+            }
+        });
+        html += '</ul>';
+        $('#usda-macro-display').html(html);
+    }
+
     function sffPopulateMacros(map) {
         $.each(map, function(k, v) {
             $('[name="sff_macros[' + k + ']"]').val(v);
         });
+        sffShowMacroPreview(map);
     }
 
 
@@ -180,6 +192,8 @@ jQuery(document).ready(function($) {
                     $('[name="sff_macros[iron]"]').val(data.iron || 0);
                     $('[name="sff_macros[potassium]"]').val(data.potassium || 0);
                     $('[name="sff_macros[magnesium]"]').val(data.magnesium || 0);
+
+                    sffShowMacroPreview(data);
 
                     // ✅ Store hidden input for attachment ID
                     if ($('#nutrition_label_image_id').length) {

--- a/wp-content/plugins/simplified-food-fitness/includes/helpers.php
+++ b/wp-content/plugins/simplified-food-fitness/includes/helpers.php
@@ -266,6 +266,8 @@ function sff_render_ingredient_form($post_id = null) {
             </div>
         </fieldset>
 
+        <div id="usda-macro-display" style="margin-top:10px; padding:10px; background:#f8f8f8; border-radius:8px; font-size:14px; color:#333;"></div>
+
         <label style="font-size:14px; color:#777;">SKU:</label>
         <input type="text" name="sff_sku" value="<?php echo esc_attr($sku); ?>" style="width:100%; padding:10px; border:1px solid #ccc; border-radius:6px; margin-bottom:10px;">
 


### PR DESCRIPTION
## Summary
- show fetched macros in Step 2 via `usda-macro-display`
- add JS helper to print macro data from USDA search and label scan

## Testing
- `npm test` *(fails: package.json not found)*
- `php -l wp-content/plugins/simplified-food-fitness/includes/helpers.php`
- `node --check wp-content/plugins/simplified-food-fitness/assets/js/sff-scripts.js`


------
https://chatgpt.com/codex/tasks/task_e_68c1f27b9ea08329ab7fdf249c82eaeb