### PR TITLE
Deduplicate USDA search results by description

### DIFF
--- a/wp-content/plugins/simplified-food-fitness/includes/ajax.php
+++ b/wp-content/plugins/simplified-food-fitness/includes/ajax.php
@@ -515,7 +515,46 @@ function sff_usda_search() {
     $body = json_decode(wp_remote_retrieve_body($resp), true);
     $items = [];
     if (!empty($body['foods'])) {
+        $grouped = [];
         foreach ($body['foods'] as $food) {
+            $description = $food['description'] ?? '';
+            $normalized = strtoupper(trim($description));
+            $timestamp = null;
+            foreach (['modifiedDate', 'publicationDate', 'publishedDate'] as $field) {
+                if (!empty($food[$field])) {
+                    $time = strtotime($food[$field]);
+                    if ($time !== false) {
+                        $timestamp = $time;
+                        break;
+                    }
+                }
+            }
+
+            if (!isset($grouped[$normalized])) {
+                $grouped[$normalized] = [
+                    'food' => $food,
+                    'timestamp' => $timestamp,
+                ];
+                continue;
+            }
+
+            $existing_timestamp = $grouped[$normalized]['timestamp'];
+            $should_replace = false;
+
+            if ($timestamp && (!$existing_timestamp || $timestamp > $existing_timestamp)) {
+                $should_replace = true;
+            }
+
+            if ($should_replace) {
+                $grouped[$normalized] = [
+                    'food' => $food,
+                    'timestamp' => $timestamp,
+                ];
+            }
+        }
+
+        foreach ($grouped as $data) {
+            $food = $data['food'];
             $items[] = [
                 'fdc_id' => $food['fdcId'],
                 'description' => $food['description'],
@@ -524,7 +563,7 @@ function sff_usda_search() {
             ];
         }
     }
-    wp_send_json_success($items);
+    wp_send_json_success(array_values($items));
 }
 add_action('wp_ajax_sff_usda_search', 'sff_usda_search');
 


### PR DESCRIPTION
## Summary
- group USDA search results by normalized description and prefer records with the newest date fields
- return the deduplicated foods list without helper metadata for frontend consumption

## Testing
- php -l wp-content/plugins/simplified-food-fitness/includes/ajax.php

------
https://chatgpt.com/codex/tasks/task_e_68d5978ee1648329a8a3bc951f3fc600