### PR TITLE
Add Add Ingredient link to header menu

### DIFF
--- a/wp-content/plugins/simplified-food-fitness/includes/shortcodes.php
+++ b/wp-content/plugins/simplified-food-fitness/includes/shortcodes.php
@@ -162,6 +162,7 @@ function sff_render_header($username, $day_type) {
                 <ul>
                     <li><a href="<?php echo esc_url( home_url( '/dashboard/' ) ); ?>">Dashboard</a></li>
                     <li><a href="<?php echo esc_url( home_url( '/my-profile/' ) ); ?>" id="sff-profile-link">Profile</a></li>
+                    <li><a href="<?php echo esc_url( home_url( '/add-ingredient/' ) ); ?>">Add Ingredient</a></li>
                     <li><a href="<?php echo esc_url( wp_logout_url( home_url() ) ); ?>">Logout</a></li>
                 </ul>
             </nav>


### PR DESCRIPTION
## Summary
- add an Add Ingredient entry to the header hamburger navigation menu for logged-in users

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d59adf8bf88329874927fff32b82f3