### PR TITLE
Expose USDA API responses for ingredient debugging

### DIFF
--- a/wp-content/plugins/simplified-food-fitness/assets/css/sff-styles.css
+++ b/wp-content/plugins/simplified-food-fitness/assets/css/sff-styles.css
@@ -211,6 +211,22 @@
     background: #E9FAB0;
 }
 
+#usda-full-response {
+    display: none;
+    font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;
+    font-size: 12px;
+    line-height: 1.45;
+    background: #fafafa;
+    border: 1px solid #d9d9d9;
+    border-radius: 8px;
+    padding: 12px;
+    margin-top: 10px;
+    max-height: 280px;
+    overflow: auto;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
 .sff-option {
     margin-bottom: 20px;
 }

--- a/wp-content/plugins/simplified-food-fitness/assets/js/sff-scripts.js
+++ b/wp-content/plugins/simplified-food-fitness/assets/js/sff-scripts.js
@@ -1,20 +1,56 @@
 jQuery(document).ready(function($) {
     function sffShowMacroPreview(map) {
-        var html = '<strong>Fetched Macros:</strong><ul>';
+        map = map || {};
+
+        var listItems = '';
+        var hasValues = false;
+
         $.each(map, function(k, v) {
             if ($('[name="sff_macros[' + k + ']"]').length) {
-                html += '<li>' + k.replace(/_/g, ' ') + ': ' + v + '</li>';
+                var numeric = parseFloat(v);
+                if (!isNaN(numeric)) {
+                    hasValues = true;
+                    listItems += '<li>' + k.replace(/_/g, ' ') + ': ' + numeric + '</li>';
+                }
             }
         });
-        html += '</ul>';
+
+        var html = '<strong>Fetched Macros:</strong>';
+        if (hasValues) {
+            html += '<ul>' + listItems + '</ul>';
+        } else {
+            html += '<p>No macro data returned from USDA.</p>';
+        }
+
         $('#usda-macro-display').html(html);
     }
 
     function sffPopulateMacros(map) {
+        map = map || {};
         $.each(map, function(k, v) {
             $('[name="sff_macros[' + k + ']"]').val(v);
         });
         sffShowMacroPreview(map);
+    }
+
+    function sffRenderUsdaRaw(raw, message) {
+        var $rawBox = $('#usda-full-response');
+        if (!$rawBox.length) {
+            return;
+        }
+
+        if (raw) {
+            try {
+                $rawBox.text(JSON.stringify(raw, null, 2));
+            } catch (err) {
+                $rawBox.text('Unable to format USDA response: ' + err.message);
+            }
+            $rawBox.show();
+        } else if (message) {
+            $rawBox.text(message).show();
+        } else {
+            $rawBox.text('No USDA response data available.').show();
+        }
     }
 
 
@@ -50,14 +86,23 @@ jQuery(document).ready(function($) {
         }
 
         if (fdc) {
+            sffRenderUsdaRaw(null, 'Loading USDA data...');
             $.post(
                 sff_ajax_obj.ajax_url,
                 { action: 'sff_usda_macros', security: sff_ajax_obj.nonce, fdc_id: fdc },
                 function(res) {
                     if (res.success) {
-                        sffPopulateMacros(res.data);
+                        var macros = res.data && res.data.macros ? res.data.macros : {};
+                        sffPopulateMacros(macros);
                         $('#sff_macro_source').val('usda');
                         $('#macro_source_text').text('USDA');
+                        var notice = res.data && res.data.notice ? res.data.notice : '';
+                        var message = notice ? notice : '';
+                        sffRenderUsdaRaw(res.data ? res.data.raw : null, message);
+                    } else {
+                        var errorMessage = res.data && res.data.message ? res.data.message : 'Unable to fetch USDA data.';
+                        sffPopulateMacros({});
+                        sffRenderUsdaRaw(null, errorMessage);
                     }
                 }
             );
@@ -516,11 +561,19 @@ jQuery(document).ready(function($) {
     $('[name="sff_brand_name"]').val($(this).text());
     $('[name="sff_fdc_id"]').val(fdc);
     $('#usda-suggestions').hide().empty();
+    sffRenderUsdaRaw(null, 'Loading USDA data...');
     $.post(sff_ajax_obj.ajax_url,{action:'sff_usda_macros',security:sff_ajax_obj.nonce,fdc_id:fdc},function(res){
       if(res.success){
-        sffPopulateMacros(res.data);
+        var macros = res.data && res.data.macros ? res.data.macros : {};
+        sffPopulateMacros(macros);
         $('#sff_macro_source').val('usda');
         $('#macro_source_text').text('USDA');
+        var notice = res.data && res.data.notice ? res.data.notice : '';
+        sffRenderUsdaRaw(res.data ? res.data.raw : null, notice);
+      } else {
+        var errorMessage = res.data && res.data.message ? res.data.message : 'Unable to fetch USDA data.';
+        sffPopulateMacros({});
+        sffRenderUsdaRaw(null, errorMessage);
       }
     });
   });

--- a/wp-content/plugins/simplified-food-fitness/includes/ajax.php
+++ b/wp-content/plugins/simplified-food-fitness/includes/ajax.php
@@ -583,12 +583,24 @@ function sff_usda_macros() {
     if (!$fdc_id) {
         wp_send_json_error('Missing FDC ID');
     }
-    $macros = sff_fetch_usda_macros($fdc_id);
-    $macros = array_intersect_key($macros, array_flip(SFF_MACRO_FIELDS));
-    if (!$macros) {
-        wp_send_json_error('Not found');
+    $raw_food = null;
+    $macros = sff_fetch_usda_macros($fdc_id, $raw_food);
+    $macros = $macros ? array_intersect_key($macros, array_flip(SFF_MACRO_FIELDS)) : [];
+
+    if (empty($raw_food)) {
+        wp_send_json_error(['message' => 'Unable to retrieve USDA data for the selected item.']);
     }
-    wp_send_json_success($macros);
+
+    $response = [
+        'macros' => $macros,
+        'raw'    => $raw_food,
+    ];
+
+    if (empty($macros)) {
+        $response['notice'] = 'No macro values were returned by USDA for this item. Please review the raw response below.';
+    }
+
+    wp_send_json_success($response);
 }
 add_action('wp_ajax_sff_usda_macros', 'sff_usda_macros');
 

--- a/wp-content/plugins/simplified-food-fitness/includes/helpers.php
+++ b/wp-content/plugins/simplified-food-fitness/includes/helpers.php
@@ -62,27 +62,48 @@ function sff_generate_meal_cards($meal_plan) {
     return $output;
 }
 
-function sff_fetch_usda_macros($fdc_id) {
+function sff_fetch_usda_macros($fdc_id, &$raw_data = null) {
+    $raw_data = null;
     $api_key = defined('SFF_USDA_API_KEY') ? SFF_USDA_API_KEY : '';
     if (empty($api_key) || empty($fdc_id)) {
         return [];
     }
 
-    $url = 'https://api.nal.usda.gov/fdc/v1/food/' . intval($fdc_id) . '?api_key=' . urlencode($api_key);
-    $response = wp_remote_get($url, ['timeout' => 15]);
+    $endpoint = 'https://api.nal.usda.gov/fdc/v1/food/' . intval($fdc_id);
+    $url = add_query_arg(
+        [
+            'api_key' => $api_key,
+            'format'  => 'full',
+        ],
+        $endpoint
+    );
+
+    $response = wp_remote_get($url, [
+        'timeout' => 20,
+        'headers' => [
+            'Accept' => 'application/json',
+        ],
+    ]);
+
     if (is_wp_error($response)) {
         return [];
     }
 
-    $data = json_decode(wp_remote_retrieve_body($response), true);
-    if (empty($data) || !is_array($data)) {
+    $body = wp_remote_retrieve_body($response);
+    if (empty($body)) {
+        return [];
+    }
+
+    $raw_data = json_decode($body, true);
+    if (empty($raw_data) || !is_array($raw_data)) {
+        $raw_data = null;
         return [];
     }
 
     $macros = array_fill_keys(SFF_MACRO_FIELDS, 0);
 
     // Parse "labelNutrients" block first (available for many branded foods).
-    if (!empty($data['labelNutrients']) && is_array($data['labelNutrients'])) {
+    if (!empty($raw_data['labelNutrients']) && is_array($raw_data['labelNutrients'])) {
         $label_map = [
             'calories'      => 'calories',
             'carbohydrates' => 'carbs',
@@ -102,14 +123,14 @@ function sff_fetch_usda_macros($fdc_id) {
         ];
 
         foreach ($label_map as $label_key => $macro_key) {
-            if (isset($data['labelNutrients'][$label_key]['value'])) {
-                $macros[$macro_key] = floatval($data['labelNutrients'][$label_key]['value']);
+            if (isset($raw_data['labelNutrients'][$label_key]['value'])) {
+                $macros[$macro_key] = floatval($raw_data['labelNutrients'][$label_key]['value']);
             }
         }
     }
 
     // Additional nutrients may live in the broader foodNutrients array.
-    if (!empty($data['foodNutrients']) && is_array($data['foodNutrients'])) {
+    if (!empty($raw_data['foodNutrients']) && is_array($raw_data['foodNutrients'])) {
         $number_map = [
             '208' => 'calories',
             '205' => 'carbs',
@@ -170,7 +191,7 @@ function sff_fetch_usda_macros($fdc_id) {
             'Thiamin' => 'thiamin',
         ];
 
-        foreach ($data['foodNutrients'] as $nutrient) {
+        foreach ($raw_data['foodNutrients'] as $nutrient) {
             $value = isset($nutrient['value']) ? floatval($nutrient['value']) : null;
             if ($value === null) {
                 continue;
@@ -344,6 +365,7 @@ function sff_render_ingredient_form($post_id = null) {
                 </fieldset>
 
                 <div id="usda-macro-display" style="margin-top:10px; padding:10px; background:#f8f8f8; border-radius:8px; font-size:14px; color:#333;"></div>
+                <pre id="usda-full-response" style="display:none; margin-top:10px; padding:12px; background:#fafafa; border:1px solid #d9d9d9; border-radius:8px; font-size:12px; color:#333; max-height:280px; overflow:auto; white-space:pre-wrap; word-break:break-word;">USDA API response will appear here after you select a food.</pre>
 
                 <label style="font-size:14px; color:#777;">SKU:</label>
                 <input type="text" name="sff_sku" value="<?php echo esc_attr($sku); ?>" style="width:100%; padding:10px; border:1px solid #ccc; border-radius:6px; margin-bottom:10px;">


### PR DESCRIPTION
## Summary
- request USDA food records with the documented parameters and capture the decoded payload alongside parsed macros
- return the raw USDA response through the AJAX endpoint so the UI can surface it while still populating macros when available
- update the ingredient form styling and scripts to preview macros clearly and show the full API response for troubleshooting

## Testing
- php -l wp-content/plugins/simplified-food-fitness/includes/helpers.php
- php -l wp-content/plugins/simplified-food-fitness/includes/ajax.php

------
https://chatgpt.com/codex/tasks/task_e_68debd0b93f48329b0ed5658c82acfcb