### PR TITLE
Handle alternate USDA nutrient value keys

### DIFF
--- a/wp-content/plugins/simplified-food-fitness/includes/helpers.php
+++ b/wp-content/plugins/simplified-food-fitness/includes/helpers.php
@@ -123,8 +123,21 @@ function sff_fetch_usda_macros($fdc_id, &$raw_data = null) {
         ];
 
         foreach ($label_map as $label_key => $macro_key) {
-            if (isset($raw_data['labelNutrients'][$label_key]['value'])) {
-                $macros[$macro_key] = floatval($raw_data['labelNutrients'][$label_key]['value']);
+            if (!isset($raw_data['labelNutrients'][$label_key]) || !is_array($raw_data['labelNutrients'][$label_key])) {
+                continue;
+            }
+
+            $entry = $raw_data['labelNutrients'][$label_key];
+            $value = null;
+
+            if (isset($entry['value'])) {
+                $value = $entry['value'];
+            } elseif (isset($entry['amount'])) {
+                $value = $entry['amount'];
+            }
+
+            if ($value !== null && $value !== '') {
+                $macros[$macro_key] = floatval($value);
             }
         }
     }
@@ -192,7 +205,14 @@ function sff_fetch_usda_macros($fdc_id, &$raw_data = null) {
         ];
 
         foreach ($raw_data['foodNutrients'] as $nutrient) {
-            $value = isset($nutrient['value']) ? floatval($nutrient['value']) : null;
+            $value = null;
+
+            if (isset($nutrient['value'])) {
+                $value = floatval($nutrient['value']);
+            } elseif (isset($nutrient['amount'])) {
+                $value = floatval($nutrient['amount']);
+            }
+
             if ($value === null) {
                 continue;
             }


### PR DESCRIPTION
## Summary
- update USDA macro parsing to accept both `value` and `amount` keys from the API
- keep returning macro data even when the API provides nutrients via the alternate key

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dec5c942808329bd3edfffbb424de7