### PR TITLE
Improve USDA ingredient response display

### DIFF
--- a/wp-content/plugins/simplified-food-fitness/assets/css/sff-styles.css
+++ b/wp-content/plugins/simplified-food-fitness/assets/css/sff-styles.css
@@ -211,20 +211,125 @@
     background: #E9FAB0;
 }
 
-#usda-full-response {
+.usda-response-box {
     display: none;
-    font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;
-    font-size: 12px;
-    line-height: 1.45;
     background: #fafafa;
     border: 1px solid #d9d9d9;
+    border-radius: 12px;
+    padding: 16px;
+    margin-top: 12px;
+    color: #1f2933;
+    font-size: 13px;
+    line-height: 1.55;
+}
+
+.usda-response-header {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 8px 12px;
+    margin-bottom: 12px;
+}
+
+.usda-response-title {
+    margin: 0;
+    font-size: 16px;
+    font-weight: 600;
+    color: #023441;
+}
+
+.usda-response-badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 2px 8px;
+    border-radius: 999px;
+    background: #e9fab0;
+    color: #023441;
+    font-weight: 600;
+    font-size: 11px;
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
+}
+
+.usda-response-meta {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 8px 16px;
+    margin-bottom: 16px;
+}
+
+.usda-response-meta span {
+    display: block;
+    color: #475467;
+    font-size: 12px;
+}
+
+.usda-response-section {
+    border-top: 1px solid #e4e7ec;
+    padding-top: 12px;
+    margin-top: 12px;
+}
+
+.usda-response-section summary {
+    cursor: pointer;
+    font-weight: 600;
+    color: #0f172a;
+    margin-bottom: 8px;
+}
+
+.usda-response-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 12px;
+}
+
+.usda-response-table th,
+.usda-response-table td {
+    padding: 6px 8px;
+    border-bottom: 1px solid #e4e7ec;
+    text-align: left;
+}
+
+.usda-response-table tbody tr:nth-child(odd) {
+    background: #f5f7fa;
+}
+
+.usda-response-note {
+    margin-top: 8px;
+    font-size: 11px;
+    color: #667085;
+}
+
+.usda-response-json {
+    font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;
+    font-size: 11px;
+    background: #fff;
+    border: 1px solid #e4e7ec;
     border-radius: 8px;
     padding: 12px;
-    margin-top: 10px;
-    max-height: 280px;
+    margin-top: 8px;
+    max-height: 220px;
     overflow: auto;
-    white-space: pre-wrap;
-    word-break: break-word;
+    white-space: pre;
+}
+
+.usda-response-message {
+    margin: 0;
+}
+
+.usda-response-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.usda-response-list li {
+    padding: 4px 0;
+    border-bottom: 1px dashed #e4e7ec;
+}
+
+.usda-response-list li:last-child {
+    border-bottom: none;
 }
 
 .sff-option {

--- a/wp-content/plugins/simplified-food-fitness/assets/js/sff-scripts.js
+++ b/wp-content/plugins/simplified-food-fitness/assets/js/sff-scripts.js
@@ -33,23 +33,228 @@ jQuery(document).ready(function($) {
         sffShowMacroPreview(map);
     }
 
+    function sffEscapeHtml(value) {
+        if (value === undefined || value === null) {
+            return '';
+        }
+        return String(value).replace(/[&<>"']/g, function(match) {
+            return ({
+                '&': '&amp;',
+                '<': '&lt;',
+                '>': '&gt;',
+                '"': '&quot;',
+                "'": '&#39;'
+            })[match];
+        });
+    }
+
+    function sffHasValue(value) {
+        return value !== undefined && value !== null && value !== '';
+    }
+
+    function sffMetaRow(label, value) {
+        if (!sffHasValue(value)) {
+            return '';
+        }
+        return '<div><strong>' + sffEscapeHtml(label) + ':</strong> <span>' + sffEscapeHtml(value) + '</span></div>';
+    }
+
+    function sffFindAttribute(attributes, attributeName) {
+        if (!Array.isArray(attributes) || !attributeName) {
+            return '';
+        }
+
+        var match = '';
+        $.each(attributes, function(_, attribute) {
+            if (match) {
+                return false;
+            }
+            if (attribute && attribute.name === attributeName && sffHasValue(attribute.value)) {
+                match = attribute.value;
+            }
+        });
+        return match;
+    }
+
+    function sffBuildNutrientSection(items) {
+        if (!Array.isArray(items) || !items.length) {
+            return '';
+        }
+
+        var rows = '';
+        var displayed = 0;
+        var total = 0;
+
+        $.each(items, function(_, nutrientItem) {
+            if (!nutrientItem || !nutrientItem.nutrient) {
+                return;
+            }
+
+            if (!sffHasValue(nutrientItem.amount)) {
+                return;
+            }
+
+            total++;
+            if (displayed >= 20) {
+                return;
+            }
+
+            var nutrient = nutrientItem.nutrient;
+            var name = nutrient.name || nutrient.number || 'Nutrient';
+            var amount = nutrientItem.amount;
+            var unit = nutrient.unitName || '';
+
+            rows += '<tr>' +
+                '<td>' + sffEscapeHtml(name) + '</td>' +
+                '<td>' + sffEscapeHtml(amount) + '</td>' +
+                '<td>' + sffEscapeHtml(unit) + '</td>' +
+            '</tr>';
+            displayed++;
+        });
+
+        if (!rows) {
+            return '';
+        }
+
+        var title = 'Food Nutrients';
+        if (total > displayed) {
+            title += ' (showing ' + displayed + ' of ' + total + ')';
+        }
+
+        var html = '<details class="usda-response-section" open>' +
+            '<summary>' + sffEscapeHtml(title) + '</summary>' +
+            '<table class="usda-response-table">' +
+                '<thead><tr><th>Nutrient</th><th>Amount</th><th>Unit</th></tr></thead>' +
+                '<tbody>' + rows + '</tbody>' +
+            '</table>';
+
+        if (total > displayed) {
+            html += '<p class="usda-response-note">Additional nutrients available in the full USDA record.</p>';
+        }
+
+        html += '</details>';
+        return html;
+    }
+
+    function sffBuildPortionSection(portions) {
+        if (!Array.isArray(portions) || !portions.length) {
+            return '';
+        }
+
+        var rows = '';
+        $.each(portions, function(_, portion) {
+            if (!portion) {
+                return;
+            }
+            var amountDisplay = sffHasValue(portion.amount) ? portion.amount : '—';
+            var modifier = portion.modifier || (portion.measureUnit && portion.measureUnit.name) || '—';
+            var gramDisplay = sffHasValue(portion.gramWeight) ? portion.gramWeight : '—';
+
+            rows += '<tr>' +
+                '<td>' + sffEscapeHtml(amountDisplay) + '</td>' +
+                '<td>' + sffEscapeHtml(modifier) + '</td>' +
+                '<td>' + sffEscapeHtml(gramDisplay) + '</td>' +
+            '</tr>';
+        });
+
+        if (!rows) {
+            return '';
+        }
+
+        return '<details class="usda-response-section" open>' +
+            '<summary>Portion Examples</summary>' +
+            '<table class="usda-response-table">' +
+                '<thead><tr><th>Amount</th><th>Measure</th><th>Grams</th></tr></thead>' +
+                '<tbody>' + rows + '</tbody>' +
+            '</table>' +
+        '</details>';
+    }
+
+    function sffBuildAttributeSection(attributes) {
+        if (!Array.isArray(attributes) || !attributes.length) {
+            return '';
+        }
+
+        var items = '';
+        $.each(attributes, function(_, attribute) {
+            if (!attribute || !attribute.name) {
+                return;
+            }
+
+            var value = sffHasValue(attribute.value) ? attribute.value : '—';
+            items += '<li><strong>' + sffEscapeHtml(attribute.name) + ':</strong> ' + sffEscapeHtml(value) + '</li>';
+        });
+
+        if (!items) {
+            return '';
+        }
+
+        return '<details class="usda-response-section">' +
+            '<summary>Additional Attributes</summary>' +
+            '<ul class="usda-response-list">' + items + '</ul>' +
+        '</details>';
+    }
+
     function sffRenderUsdaRaw(raw, message) {
         var $rawBox = $('#usda-full-response');
         if (!$rawBox.length) {
             return;
         }
 
-        if (raw) {
-            try {
-                $rawBox.text(JSON.stringify(raw, null, 2));
-            } catch (err) {
-                $rawBox.text('Unable to format USDA response: ' + err.message);
+        if (raw && typeof raw === 'object') {
+            var headerTitle = raw.description || 'USDA Food Item';
+            var headerHtml = '<div class="usda-response-header">' +
+                '<h4 class="usda-response-title">' + sffEscapeHtml(headerTitle) + '</h4>';
+
+            if (sffHasValue(raw.fdcId)) {
+                headerHtml += '<span class="usda-response-badge">FDC ' + sffEscapeHtml(raw.fdcId) + '</span>';
             }
-            $rawBox.show();
+
+            if (sffHasValue(raw.dataType)) {
+                headerHtml += '<span class="usda-response-badge">' + sffEscapeHtml(raw.dataType) + '</span>';
+            }
+
+            headerHtml += '</div>';
+
+            var metaHtml = '';
+            metaHtml += sffMetaRow('Publication Date', raw.publicationDate);
+            metaHtml += sffMetaRow('Category', raw.foodCategory && raw.foodCategory.description);
+            metaHtml += sffMetaRow('Food Class', raw.foodClass);
+            metaHtml += sffMetaRow('Scientific Name', sffFindAttribute(raw.foodAttributes, 'Scientific Name'));
+            if (Array.isArray(raw.foodPortions) && raw.foodPortions.length) {
+                metaHtml += sffMetaRow('Portion Options', raw.foodPortions.length);
+            }
+
+            var sections = '';
+            sections += sffBuildNutrientSection(raw.foodNutrients);
+            sections += sffBuildPortionSection(raw.foodPortions);
+            sections += sffBuildAttributeSection(raw.foodAttributes);
+
+            var jsonHtml = '';
+            try {
+                jsonHtml = '<details class="usda-response-section">' +
+                    '<summary>Full USDA JSON</summary>' +
+                    '<pre class="usda-response-json">' + sffEscapeHtml(JSON.stringify(raw, null, 2)) + '</pre>' +
+                '</details>';
+            } catch (err) {
+                jsonHtml = '<p class="usda-response-message">Unable to format USDA response: ' + sffEscapeHtml(err.message) + '</p>';
+            }
+
+            var html = headerHtml;
+            if (metaHtml) {
+                html += '<div class="usda-response-meta">' + metaHtml + '</div>';
+            }
+            if (message) {
+                html += '<p class="usda-response-note">' + sffEscapeHtml(message) + '</p>';
+            }
+            html += sections;
+            html += jsonHtml;
+
+            $rawBox.html(html).show();
         } else if (message) {
-            $rawBox.text(message).show();
+            $rawBox.html('<p class="usda-response-message">' + sffEscapeHtml(message) + '</p>').show();
         } else {
-            $rawBox.text('No USDA response data available.').show();
+            $rawBox.html('<p class="usda-response-message">No USDA response data available.</p>').show();
         }
     }
 

--- a/wp-content/plugins/simplified-food-fitness/includes/helpers.php
+++ b/wp-content/plugins/simplified-food-fitness/includes/helpers.php
@@ -385,7 +385,9 @@ function sff_render_ingredient_form($post_id = null) {
                 </fieldset>
 
                 <div id="usda-macro-display" style="margin-top:10px; padding:10px; background:#f8f8f8; border-radius:8px; font-size:14px; color:#333;"></div>
-                <pre id="usda-full-response" style="display:none; margin-top:10px; padding:12px; background:#fafafa; border:1px solid #d9d9d9; border-radius:8px; font-size:12px; color:#333; max-height:280px; overflow:auto; white-space:pre-wrap; word-break:break-word;">USDA API response will appear here after you select a food.</pre>
+                <div id="usda-full-response" class="usda-response-box" style="display:none;">
+                    <p class="usda-response-message">USDA API response will appear here after you select a food.</p>
+                </div>
 
                 <label style="font-size:14px; color:#777;">SKU:</label>
                 <input type="text" name="sff_sku" value="<?php echo esc_attr($sku); ?>" style="width:100%; padding:10px; border:1px solid #ccc; border-radius:6px; margin-bottom:10px;">


### PR DESCRIPTION
## Summary
- replace the raw USDA response textarea with a styled container on the ingredient form
- render the USDA API response into readable sections for nutrients, portions, attributes, and include the raw JSON in a collapsible block
- add styling for the new USDA response layout

## Testing
- not run (WordPress site)

------
https://chatgpt.com/codex/tasks/task_e_68dec8c5a7308329a5f849bda623a78b