### PR TITLE
Enhance ingredient search with shared and personal databases

### DIFF
--- a/wp-content/plugins/simplified-food-fitness/assets/css/sff-styles.css
+++ b/wp-content/plugins/simplified-food-fitness/assets/css/sff-styles.css
@@ -184,31 +184,90 @@
     font-family: "Inter", sans-serif;
 }
 
-/* USDA Autocomplete Dropdown */
-#usda-suggestions {
+/* Ingredient Database Dropdown */
+#sff-ingredient-suggestions {
     position: absolute;
     top: 100%;
     left: 0;
     right: 0;
     background: #fff;
-    border: 1px solid #ccc;
-    border-radius: 4px;
+    border: 1px solid #cfd8dc;
+    border-radius: 8px;
     z-index: 1000;
-    max-height: 200px;
+    max-height: 240px;
     overflow-y: auto;
+    box-shadow: 0 8px 18px rgba(2, 52, 65, 0.12);
+    padding: 4px 0;
 }
-#usda-suggestions ul {
+#sff-ingredient-suggestions ul {
     list-style: none;
     margin: 0;
     padding: 0;
 }
-#usda-suggestions li {
-    padding: 8px 10px;
+#sff-ingredient-suggestions li {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding: 10px 14px;
     cursor: pointer;
+    border-bottom: 1px solid #eef2f3;
 }
-#usda-suggestions li:hover,
-#usda-suggestions li.active {
+#sff-ingredient-suggestions li:last-child {
+    border-bottom: none;
+}
+#sff-ingredient-suggestions li:hover,
+#sff-ingredient-suggestions li.active {
     background: #E9FAB0;
+}
+.sff-suggestion-name {
+    font-weight: 600;
+    color: #023441;
+}
+.sff-suggestion-meta {
+    font-size: 12px;
+    color: #5f6f64;
+}
+.sff-suggestion-badge {
+    display: inline-flex;
+    align-items: center;
+    width: fit-content;
+    margin-top: 2px;
+    padding: 2px 8px;
+    border-radius: 999px;
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.02em;
+}
+.sff-badge-personal {
+    background: #023441;
+    color: #E9FAB0;
+}
+.sff-badge-general {
+    background: #E9FAB0;
+    color: #023441;
+}
+.sff-suggestions-empty {
+    padding: 14px;
+    text-align: center;
+    color: #5f6f64;
+    font-size: 14px;
+}
+.sff-open-label-scan {
+    display: block;
+    width: calc(100% - 20px);
+    margin: 8px auto 10px;
+    padding: 10px 12px;
+    border: none;
+    border-radius: 6px;
+    background: #023441;
+    color: #E9FAB0;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.2s ease;
+}
+.sff-open-label-scan:hover {
+    background: #03586a;
 }
 
 .usda-response-box {

--- a/wp-content/plugins/simplified-food-fitness/assets/js/sff-scripts.js
+++ b/wp-content/plugins/simplified-food-fitness/assets/js/sff-scripts.js
@@ -24,8 +24,26 @@ jQuery(document).ready(function($) {
         return values;
     }
 
+    function sffNormalizeMacroSource(source) {
+        if (!source || typeof source !== 'string') {
+            return source || '';
+        }
+        var normalized = source.toLowerCase();
+        if (normalized.indexOf('personal') !== -1) {
+            return 'personal';
+        }
+        if (normalized.indexOf('general') !== -1) {
+            return 'general';
+        }
+        if (normalized.indexOf('database') !== -1) {
+            return 'database';
+        }
+        return source;
+    }
+
     function sffShowMacroSummary(map, source) {
         map = map || {};
+        source = sffNormalizeMacroSource(source);
         var $summary = $('#sff-macro-summary');
         if (!$summary.length) {
             return;
@@ -68,6 +86,12 @@ jQuery(document).ready(function($) {
             title = 'Values from USDA';
         } else if (source === 'manual') {
             title = 'Values from Manual Entry';
+        } else if (source === 'personal') {
+            title = 'Values from My Ingredients';
+        } else if (source === 'general') {
+            title = 'Values from General Database';
+        } else if (source === 'database') {
+            title = 'Values from Ingredient Database';
         }
 
         var html = '<div class="sff-macro-summary-title">' + title + '</div>' +
@@ -331,27 +355,29 @@ jQuery(document).ready(function($) {
         var hasImage = $('#front_image_attachment_id').val() ||
             ($('#sff_front_image_upload')[0] && $('#sff_front_image_upload')[0].files.length > 0);
 
-        if (!hasImage) {
+        if (sffForceLabelScan) {
+            $('#sff_scan_fields').show();
+        } else if (!hasImage) {
             $('#sff_scan_fields').hide();
         } else {
             $('#sff_scan_fields').show();
         }
+        sffForceLabelScan = false;
 
-        // Set the Step 2 category from the USDA filter
         var categorySelect = $('select[name="sff_ingredient_category"]');
-        var usdaCategory = $('#usda-category-filter').val();
-        if (categorySelect.length && usdaCategory) {
-            categorySelect.val(usdaCategory);
-        }
-
         var fdc = $('#sff_fdc_id').val();
-        if (fdc && categorySelect.length) {
-            // Hide/disable category selection when a USDA match is used
+        var macroState = sffNormalizeMacroSource($('#sff_macro_source').val());
+        var shouldFetchUsda = fdc && (!macroState || macroState === 'usda');
+
+        if (shouldFetchUsda && categorySelect.length) {
             categorySelect.prop('disabled', true).hide();
             categorySelect.prev('label').hide();
+        } else if (categorySelect.length) {
+            categorySelect.prop('disabled', false).show();
+            categorySelect.prev('label').show();
         }
 
-        if (fdc) {
+        if (shouldFetchUsda) {
             sffRenderUsdaRaw(null, 'Loading USDA data...');
             $.post(
                 sff_ajax_obj.ajax_url,
@@ -372,10 +398,8 @@ jQuery(document).ready(function($) {
                     }
                 }
             );
-        } else if (categorySelect.length) {
-            // Ensure category dropdown is visible if no USDA match
-            categorySelect.prop('disabled', false).show();
-            categorySelect.prev('label').show();
+        } else {
+            $('#usda-full-response').hide();
         }
     });
 
@@ -822,87 +846,213 @@ jQuery(document).ready(function($) {
   toggleClientDayRequired('[name="client[]busy_days"]');
   toggleClientDayRequired('[name="client[]activity_days"]');
 
-  var usdaIndex = -1;
+  var $ingredientNameField = $('#sff_product_name');
+  if (!$ingredientNameField.length) {
+    $ingredientNameField = $('[name="sff_brand_name"]');
+  }
+  var sffSuggestionIndex = -1;
+  var sffDatabaseTimer = null;
+  var sffLastDatabaseResults = [];
+  var sffSettingProductName = false;
+  var sffForceLabelScan = false;
 
-  $('[name="sff_brand_name"]').on('keydown', function(e){
-    var items = $('#usda-suggestions li');
-    if(!items.length) return;
-    if(e.key === 'ArrowDown'){
-      e.preventDefault();
-      usdaIndex = (usdaIndex + 1) % items.length;
-      items.removeClass('active').eq(usdaIndex).addClass('active');
-    } else if(e.key === 'ArrowUp'){
-      e.preventDefault();
-      usdaIndex = (usdaIndex - 1 + items.length) % items.length;
-      items.removeClass('active').eq(usdaIndex).addClass('active');
-    } else if(e.key === 'Enter' && usdaIndex >= 0){
-      e.preventDefault();
-      items.eq(usdaIndex).trigger('click');
-    }
-  });
-
-  function usdaSearch(){
-    var query = $('[name="sff_brand_name"]').val();
-    var category = $('#usda-category-filter').val();
-    if(query.length < 2){
-      $('#usda-suggestions').hide().empty();
-      usdaIndex = -1;
-      return;
-    }
-    $.post(sff_ajax_obj.ajax_url,{action:'sff_usda_search',security:sff_ajax_obj.nonce,query:query,category:category},function(res){
-      if(res.success){
-        var list = $('<ul/>');
-        $.each(res.data,function(i,item){
-          if(!category || (item.foodCategory && item.foodCategory.toLowerCase().includes(category.toLowerCase())) || (item.dataType && item.dataType.toLowerCase().includes(category.toLowerCase()))){
-            list.append($('<li>').text(item.description).attr('data-fdc',item.fdc_id));
-          }
-        });
-        if(list.children().length){
-          $('#usda-suggestions').html(list).show();
-        } else {
-          $('#usda-suggestions').hide().empty();
-        }
-        usdaIndex = -1;
-      } else {
-        $('#usda-suggestions').hide().empty();
-      }
-    });
+  function sffClearIngredientSelectionMeta() {
+    $('#sff_source_ingredient').val('');
+    $('#sff_selected_owner').val('');
+    $('#sff-ingredient-selection-note').hide().empty();
   }
 
-  $('#usda-search-button').on('click', function(){
-    usdaSearch();
-  });
-  $('[name="sff_brand_name"]').on('keypress', function(e){
-    if(e.key === 'Enter'){
-      e.preventDefault();
-      usdaSearch();
+  function sffRenderIngredientSuggestions(items, query) {
+    var $container = $('#sff-ingredient-suggestions');
+    sffSuggestionIndex = -1;
+    if (!$container.length) {
+      return;
     }
-  });
-  $('#usda-category-filter').off('change').on('change', function(){
-    $('[name="sff_fdc_id"]').val('');
-    usdaSearch();
+    if (!items || !items.length) {
+      var emptyHtml = '<div class="sff-suggestions-empty">No ingredients found in the selected database.</div>';
+      emptyHtml += '<button type="button" class="sff-open-label-scan" data-query="' + sffEscapeHtml(query || '') + '">➕ Scan a label to add to My Ingredients</button>';
+      $container.html(emptyHtml).show();
+      return;
+    }
+    var $list = $('<ul/>');
+    items.forEach(function(item, index) {
+      var label = item.brand_name || item.title || '';
+      var badge = item.owner_badge || (item.is_personal ? 'My Ingredient' : 'General Database');
+      var badgeClass = item.owner_badge_class || (item.is_personal ? 'personal' : 'general');
+      var $li = $('<li/>')
+        .attr('data-index', index)
+        .addClass('sff-ingredient-suggestion')
+        .append('<span class="sff-suggestion-name">' + sffEscapeHtml(label) + '</span>' +
+                '<span class="sff-suggestion-badge sff-badge-' + sffEscapeHtml(badgeClass) + '">' + sffEscapeHtml(badge) + '</span>');
+      if (item.serving_size) {
+        $li.append('<span class="sff-suggestion-meta">' + sffEscapeHtml(item.serving_size) + '</span>');
+      }
+      $li.data('item', item);
+      $list.append($li);
+    });
+    $container.html($list).show();
+  }
+
+  function sffSearchIngredientDatabase() {
+    if (!$ingredientNameField.length) {
+      return;
+    }
+    var query = $ingredientNameField.val();
+    if (!query || query.trim().length < 2) {
+      $('#sff-ingredient-suggestions').hide().empty();
+      return;
+    }
+    var scope = $('#sff-ingredient-scope').val() || 'all';
+    $.post(
+      sff_ajax_obj.ajax_url,
+      {
+        action: 'sff_search_user_ingredients',
+        security: sff_ajax_obj.nonce,
+        query: query,
+        scope: scope
+      },
+      function(res) {
+        if (res && res.success && res.data) {
+          var items = Array.isArray(res.data.items) ? res.data.items : [];
+          sffLastDatabaseResults = items;
+          sffRenderIngredientSuggestions(items, res.data.query || query);
+        } else {
+          sffLastDatabaseResults = [];
+          $('#sff-ingredient-suggestions').hide().empty();
+        }
+      }
+    );
+  }
+
+  $ingredientNameField.on('input', function() {
+    if (sffSettingProductName) {
+      return;
+    }
+    sffClearIngredientSelectionMeta();
+    $('#sff_macro_source').val('manual');
+    $('#macro_source_text').text('Manual');
+    $('#usda-full-response').hide();
+    clearTimeout(sffDatabaseTimer);
+    var value = $ingredientNameField.val();
+    if (!value || value.trim().length < 2) {
+      $('#sff-ingredient-suggestions').hide().empty();
+      return;
+    }
+    sffDatabaseTimer = setTimeout(function() {
+      sffSearchIngredientDatabase();
+    }, 250);
   });
 
-    $('#usda-suggestions').on('click','li',function(){
-    var fdc = $(this).data('fdc');
-    $('[name="sff_brand_name"]').val($(this).text());
-    $('[name="sff_fdc_id"]').val(fdc);
-    $('#usda-suggestions').hide().empty();
-    sffRenderUsdaRaw(null, 'Loading USDA data...');
-    $.post(sff_ajax_obj.ajax_url,{action:'sff_usda_macros',security:sff_ajax_obj.nonce,fdc_id:fdc},function(res){
-      if(res.success){
-        var macros = res.data && res.data.macros ? res.data.macros : {};
-        sffPopulateMacros(macros, 'usda');
-        $('#sff_macro_source').val('usda');
-        $('#macro_source_text').text('USDA');
-        var notice = res.data && res.data.notice ? res.data.notice : '';
-        sffRenderUsdaRaw(res.data ? res.data.raw : null, notice);
-      } else {
-        var errorMessage = res.data && res.data.message ? res.data.message : 'Unable to fetch USDA data.';
-        sffPopulateMacros({}, 'clear');
-        sffRenderUsdaRaw(null, errorMessage);
+  $ingredientNameField.on('keydown', function(e) {
+    var $items = $('#sff-ingredient-suggestions li');
+    if (!$items.length) {
+      return;
+    }
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      sffSuggestionIndex = (sffSuggestionIndex + 1) % $items.length;
+      $items.removeClass('active').eq(sffSuggestionIndex).addClass('active');
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      sffSuggestionIndex = (sffSuggestionIndex - 1 + $items.length) % $items.length;
+      $items.removeClass('active').eq(sffSuggestionIndex).addClass('active');
+    } else if (e.key === 'Enter' && sffSuggestionIndex >= 0) {
+      e.preventDefault();
+      $items.eq(sffSuggestionIndex).trigger('click');
+    } else if (e.key === 'Escape') {
+      $('#sff-ingredient-suggestions').hide().empty();
+      sffSuggestionIndex = -1;
+    }
+  });
+
+  $('#sff-database-search-button').on('click', function() {
+    sffSearchIngredientDatabase();
+  });
+
+  $('#sff-ingredient-scope').on('change', function() {
+    sffSearchIngredientDatabase();
+  });
+
+  $(document).on('click', '.sff-ingredient-suggestion', function() {
+    var $item = $(this);
+    var item = $item.data('item');
+    if (!item) {
+      var idx = parseInt($item.attr('data-index'), 10);
+      if (!isNaN(idx) && sffLastDatabaseResults[idx]) {
+        item = sffLastDatabaseResults[idx];
       }
-    });
+    }
+    if (!item) {
+      return;
+    }
+
+    sffSettingProductName = true;
+    $ingredientNameField.val(item.brand_name || item.title || '');
+    sffSettingProductName = false;
+
+    $('#sff-ingredient-suggestions').hide().empty();
+    sffSuggestionIndex = -1;
+
+    $('#sff_source_ingredient').val(item.id || '');
+    $('#sff_selected_owner').val(item.owner_type || '');
+    var macroText = item.is_personal ? 'My Ingredients' : 'General Database';
+    $('#macro_source_text').text(macroText);
+    $('#sff_macro_source').val(item.is_personal ? 'database_personal' : 'database_general');
+
+    if (item.fdc_id) {
+      $('#sff_fdc_id').val(item.fdc_id);
+    } else {
+      $('#sff_fdc_id').val('');
+    }
+
+    if (item.serving_size) {
+      $('#sff_serving_size').val(item.serving_size);
+    }
+    if (item.servings !== undefined && item.servings !== null && item.servings !== '') {
+      $('#sff_servings').val(item.servings);
+    }
+
+    if (item.category_id) {
+      var $categorySelect = $('select[name="sff_ingredient_category"]');
+      if ($categorySelect.length) {
+        $categorySelect.prop('disabled', false).show();
+        $categorySelect.prev('label').show();
+        $categorySelect.val(item.category_id);
+      }
+    }
+
+    if (item.price !== undefined && item.price !== null && !isNaN(parseFloat(item.price))) {
+      var $priceField = $('[name="sff_price"]');
+      if ($priceField.length) {
+        $priceField.val(parseFloat(item.price));
+      }
+    }
+
+    sffPopulateMacros(item.macros || {}, item.is_personal ? 'personal' : 'general');
+
+    var noteMessage = item.is_personal ? 'Loaded from your personal ingredient library.' : 'Loaded from the shared ingredient database.';
+    $('#sff-ingredient-selection-note').text(noteMessage).show();
+
+    $('#usda-full-response').hide().empty();
+  });
+
+  $(document).on('click', '.sff-open-label-scan', function(e) {
+    e.preventDefault();
+    var query = $(this).data('query');
+    if (query) {
+      sffSettingProductName = true;
+      $ingredientNameField.val(query);
+      sffSettingProductName = false;
+    }
+    sffForceLabelScan = true;
+    $('#sff-ingredient-suggestions').hide().empty();
+    sffSuggestionIndex = -1;
+    $('#sff_source_ingredient').val('');
+    $('#sff_selected_owner').val('');
+    $('#next_step_button').trigger('click');
+    setTimeout(function() {
+      $('#sff_nutrition_label_upload').trigger('focus');
+    }, 250);
   });
 
   $('#sff-wizard-step-2').on('input','[name^="sff_macros"]',function(){
@@ -911,5 +1061,6 @@ jQuery(document).ready(function($) {
     sffShowMacroSummary(sffCollectMacroValues(), 'manual');
   });
 
-  sffShowMacroSummary(sffCollectMacroValues(), $('#sff_macro_source').val() || 'manual');
-  });
+  var initialMacroSource = $('#sff_macro_source').val() || 'manual';
+  sffShowMacroSummary(sffCollectMacroValues(), sffNormalizeMacroSource(initialMacroSource));
+});

--- a/wp-content/plugins/simplified-food-fitness/includes/ajax.php
+++ b/wp-content/plugins/simplified-food-fitness/includes/ajax.php
@@ -234,6 +234,147 @@ function sff_scan_product_name() {
 
 add_action('wp_ajax_sff_scan_product_name', 'sff_scan_product_name');
 
+function sff_search_user_ingredients() {
+    if (!isset($_POST['security']) || !wp_verify_nonce($_POST['security'], 'sff_scan_nonce')) {
+        wp_send_json_error(['message' => 'Nonce verification failed.']);
+    }
+
+    if (!is_user_logged_in()) {
+        wp_send_json_error(['message' => 'You must be logged in to search ingredients.']);
+    }
+
+    $user_id = get_current_user_id();
+    $term = isset($_POST['query']) ? sanitize_text_field(wp_unslash($_POST['query'])) : '';
+    $term = trim($term);
+    $scope = isset($_POST['scope']) ? sanitize_text_field(wp_unslash($_POST['scope'])) : 'all';
+
+    if (strlen($term) < 2) {
+        wp_send_json_success([
+            'items' => [],
+            'query' => $term,
+            'scope' => $scope,
+        ]);
+    }
+
+    $args = [
+        'post_type' => 'ingredient',
+        'post_status' => 'publish',
+        'posts_per_page' => 12,
+        's' => $term,
+        'orderby' => 'title',
+        'order' => 'ASC',
+        'fields' => 'ids',
+    ];
+
+    if (!user_can($user_id, 'manage_options')) {
+        if ($scope === 'personal') {
+            $args['meta_query'] = [
+                [
+                    'key' => '_sff_owner_id',
+                    'value' => $user_id,
+                    'compare' => '=',
+                    'type' => 'NUMERIC',
+                ],
+            ];
+        } elseif ($scope === 'general') {
+            $args['meta_query'] = [
+                'relation' => 'OR',
+                [
+                    'key' => '_sff_owner_id',
+                    'value' => 0,
+                    'compare' => '=',
+                    'type' => 'NUMERIC',
+                ],
+                [
+                    'key' => '_sff_owner_id',
+                    'compare' => 'NOT EXISTS',
+                ],
+            ];
+        } else {
+            $args['meta_query'] = [
+                'relation' => 'OR',
+                [
+                    'key' => '_sff_owner_id',
+                    'value' => 0,
+                    'compare' => '=',
+                    'type' => 'NUMERIC',
+                ],
+                [
+                    'key' => '_sff_owner_id',
+                    'value' => $user_id,
+                    'compare' => '=',
+                    'type' => 'NUMERIC',
+                ],
+                [
+                    'key' => '_sff_owner_id',
+                    'compare' => 'NOT EXISTS',
+                ],
+            ];
+        }
+    } else {
+        if ($scope === 'personal') {
+            $args['author'] = $user_id;
+        }
+    }
+
+    $query = new WP_Query($args);
+
+    $items = [];
+    if ($query->have_posts()) {
+        foreach ($query->posts as $ingredient_id) {
+            if (!sff_user_can_access_ingredient($ingredient_id, $user_id)) {
+                continue;
+            }
+            if ($scope === 'personal' && sff_is_general_ingredient($ingredient_id)) {
+                continue;
+            }
+            if ($scope === 'general' && !sff_is_general_ingredient($ingredient_id)) {
+                continue;
+            }
+
+            $payload = sff_prepare_ingredient_payload($ingredient_id, $user_id);
+            if ($payload) {
+                $items[] = $payload;
+            }
+        }
+    }
+
+    wp_send_json_success([
+        'items' => $items,
+        'query' => $term,
+        'scope' => $scope,
+    ]);
+}
+add_action('wp_ajax_sff_search_user_ingredients', 'sff_search_user_ingredients');
+
+function sff_get_ingredient_details() {
+    if (!isset($_POST['security']) || !wp_verify_nonce($_POST['security'], 'sff_scan_nonce')) {
+        wp_send_json_error(['message' => 'Nonce verification failed.']);
+    }
+
+    if (!is_user_logged_in()) {
+        wp_send_json_error(['message' => 'You must be logged in to load ingredient details.']);
+    }
+
+    $ingredient_id = isset($_POST['ingredient_id']) ? intval($_POST['ingredient_id']) : 0;
+    if (!$ingredient_id) {
+        wp_send_json_error(['message' => 'Invalid ingredient.']);
+    }
+
+    $user_id = get_current_user_id();
+    if (!sff_user_can_access_ingredient($ingredient_id, $user_id)) {
+        wp_send_json_error(['message' => 'You do not have access to this ingredient.']);
+    }
+
+    $payload = sff_prepare_ingredient_payload($ingredient_id, $user_id);
+    if (!$payload) {
+        wp_send_json_error(['message' => 'Unable to load ingredient data.']);
+    }
+
+    wp_send_json_success($payload);
+}
+add_action('wp_ajax_sff_get_ingredient_details', 'sff_get_ingredient_details');
+
 
 
 function sff_handle_ingredient_submission() {
@@ -281,6 +422,9 @@ function sff_handle_ingredient_submission() {
         ]
     ];
 
+    $source_ingredient = isset($_POST['sff_source_ingredient']) ? intval($_POST['sff_source_ingredient']) : 0;
+    $selected_owner    = isset($_POST['sff_selected_owner']) ? sanitize_text_field($_POST['sff_selected_owner']) : '';
+
     // Debugging: Log the data being saved
     error_log('Submitted Data: ' . print_r($data, true));
 
@@ -295,6 +439,8 @@ function sff_handle_ingredient_submission() {
         wp_die('Failed to create ingredient post.');
     }
 
+    sff_assign_ingredient_owner($post_id, null, true);
+
     // Save meta data
     update_post_meta($post_id, '_sff_brand_name', $data['brand_name']);
     update_post_meta($post_id, '_sff_serving_size', $data['serving_size']);
@@ -304,6 +450,12 @@ function sff_handle_ingredient_submission() {
     update_post_meta($post_id, '_sff_sku', $data['sku']);
     update_post_meta($post_id, '_sff_affiliate_link', $data['affiliate_link']);
     update_post_meta($post_id, '_sff_price', $data['price']);
+    if ($source_ingredient) {
+        update_post_meta($post_id, '_sff_source_ingredient', $source_ingredient);
+    }
+    if (!empty($selected_owner)) {
+        update_post_meta($post_id, '_sff_selected_owner', $selected_owner);
+    }
 
     // Handle image uploads properly
     require_once(ABSPATH . 'wp-admin/includes/file.php');

--- a/wp-content/plugins/simplified-food-fitness/includes/helpers.php
+++ b/wp-content/plugins/simplified-food-fitness/includes/helpers.php
@@ -3,6 +3,139 @@ if (!defined('ABSPATH')) {
     exit; // Exit if accessed directly
 }
 
+function sff_get_ingredient_owner_id($ingredient_id) {
+    $ingredient_id = intval($ingredient_id);
+    if (!$ingredient_id) {
+        return 0;
+    }
+
+    $owner = get_post_meta($ingredient_id, '_sff_owner_id', true);
+    if ($owner !== '' && $owner !== null) {
+        return intval($owner);
+    }
+
+    $post = get_post($ingredient_id);
+    if (!$post) {
+        return 0;
+    }
+
+    if (user_can($post->post_author, 'manage_options')) {
+        return 0;
+    }
+
+    return intval($post->post_author);
+}
+
+function sff_assign_ingredient_owner($ingredient_id, $user_id = null, $force = false) {
+    $ingredient_id = intval($ingredient_id);
+    if (!$ingredient_id) {
+        return;
+    }
+
+    if ($user_id === null) {
+        $user_id = get_current_user_id();
+        if ($user_id && user_can($user_id, 'manage_options')) {
+            $user_id = 0;
+        }
+    }
+
+    if (!$force) {
+        $current = get_post_meta($ingredient_id, '_sff_owner_id', true);
+        if ($current !== '' && $current !== null) {
+            return;
+        }
+    }
+
+    update_post_meta($ingredient_id, '_sff_owner_id', intval($user_id));
+}
+
+function sff_user_can_access_ingredient($ingredient_id, $user_id = 0) {
+    $ingredient_id = intval($ingredient_id);
+    if (!$ingredient_id) {
+        return false;
+    }
+
+    if (!$user_id) {
+        $user_id = get_current_user_id();
+    }
+
+    if ($user_id && user_can($user_id, 'manage_options')) {
+        return true;
+    }
+
+    $owner_id = sff_get_ingredient_owner_id($ingredient_id);
+    if ($owner_id === 0) {
+        return true;
+    }
+
+    return $owner_id === intval($user_id);
+}
+
+function sff_is_general_ingredient($ingredient_id) {
+    return sff_get_ingredient_owner_id($ingredient_id) === 0;
+}
+
+function sff_prepare_ingredient_payload($ingredient_id, $user_id = 0) {
+    $ingredient_id = intval($ingredient_id);
+    if (!$ingredient_id) {
+        return null;
+    }
+
+    $post = get_post($ingredient_id);
+    if (!$post || $post->post_type !== 'ingredient') {
+        return null;
+    }
+
+    if (!$user_id) {
+        $user_id = get_current_user_id();
+    }
+
+    $macros_raw = get_post_meta($ingredient_id, '_sff_macros', true);
+    $macros = array_fill_keys(SFF_MACRO_FIELDS, 0);
+    if (is_array($macros_raw)) {
+        foreach (SFF_MACRO_FIELDS as $field) {
+            if (isset($macros_raw[$field])) {
+                $macros[$field] = floatval($macros_raw[$field]);
+            }
+        }
+    }
+
+    $terms = wp_get_post_terms($ingredient_id, 'ingredient_category', ['number' => 1]);
+    $category_id = 0;
+    $category_name = '';
+    if (!is_wp_error($terms) && !empty($terms)) {
+        $category_id = intval($terms[0]->term_id);
+        $category_name = $terms[0]->name;
+    }
+
+    $owner_id = sff_get_ingredient_owner_id($ingredient_id);
+    $is_personal = ($owner_id && $owner_id === intval($user_id));
+    $is_general = ($owner_id === 0);
+
+    $owner_badge = $is_personal ? __('My Ingredient', 'simplified-food-fitness') : __('General Database', 'simplified-food-fitness');
+    $owner_badge_class = $is_personal ? 'personal' : ($is_general ? 'general' : 'restricted');
+
+    return [
+        'id' => $ingredient_id,
+        'title' => get_the_title($ingredient_id),
+        'brand_name' => get_post_meta($ingredient_id, '_sff_brand_name', true) ?: get_the_title($ingredient_id),
+        'serving_size' => get_post_meta($ingredient_id, '_sff_serving_size', true),
+        'servings' => get_post_meta($ingredient_id, '_sff_servings', true),
+        'macros' => $macros,
+        'macro_source' => get_post_meta($ingredient_id, '_sff_macro_source', true),
+        'fdc_id' => get_post_meta($ingredient_id, '_sff_fdc_id', true),
+        'category_id' => $category_id,
+        'category_name' => $category_name,
+        'owner_id' => $owner_id,
+        'owner_type' => $is_personal ? 'personal' : ($is_general ? 'general' : 'restricted'),
+        'is_personal' => $is_personal,
+        'is_general' => $is_general,
+        'owner_badge' => $owner_badge,
+        'owner_badge_class' => $owner_badge_class,
+        'price' => floatval(get_post_meta($ingredient_id, '_sff_price', true)),
+    ];
+}
+
 function sff_generate_grocery_list($meal_plan) {
     if (empty($meal_plan) || !is_string($meal_plan)) {
         return '<p>No grocery list available.</p>';
@@ -289,17 +422,17 @@ function sff_render_ingredient_form($post_id = null) {
                 <p style="font-size:14px; color:#777;">Choose a source below to begin.</p>
 
                 <div class="sff-option">
-                    <h4 style="font-size:16px; color:#333; margin-bottom:8px;">Option 1: Search USDA Database</h4>
+                    <h4 style="font-size:16px; color:#333; margin-bottom:8px;">Option 1: Search Ingredient Database</h4>
+                    <p style="font-size:13px; color:#5f6f64; margin-top:0;">Browse shared ingredients from your dietitian and items you have already added.</p>
                     <div style="position:relative;">
                         <input type="text" name="sff_brand_name" id="sff_product_name" value="<?php echo esc_attr($brand_name); ?>" placeholder="Start typing e.g., Banana" style="width:100%; padding:10px; border:1px solid #ccc; border-radius:6px; margin-bottom:10px;">
-                        <select id="usda-category-filter" style="width:100%; padding:10px; border:1px solid #ccc; border-radius:6px; margin-bottom:10px;">
-                            <option value="">All Categories</option>
-                            <option value="Fruits">Fruits</option>
-                            <option value="Vegetables">Vegetables</option>
-                            <option value="Grains">Grains</option>
+                        <select id="sff-ingredient-scope" style="width:100%; padding:10px; border:1px solid #ccc; border-radius:6px; margin-bottom:10px;">
+                            <option value="all">All Ingredients</option>
+                            <option value="personal">My Ingredients</option>
+                            <option value="general">General Database</option>
                         </select>
-                        <button type="button" id="usda-search-button" style="background:#42b14c; color:white; border:none; padding:10px; border-radius:6px; cursor:pointer; font-size:14px; width:100%; margin-bottom:10px;">🔍 Search</button>
-                        <div id="usda-suggestions" style="display:none;"></div>
+                        <button type="button" id="sff-database-search-button" style="background:#42b14c; color:white; border:none; padding:10px; border-radius:6px; cursor:pointer; font-size:14px; width:100%; margin-bottom:10px;">🔍 Search Database</button>
+                        <div id="sff-ingredient-suggestions" class="sff-ingredient-suggestions" style="display:none;"></div>
                     </div>
                 </div>
 
@@ -338,6 +471,10 @@ function sff_render_ingredient_form($post_id = null) {
                 </div>
 
                 <input type="hidden" name="sff_fdc_id" id="sff_fdc_id" value="<?php echo esc_attr($fdc_id); ?>">
+                <input type="hidden" name="sff_source_ingredient" id="sff_source_ingredient" value="">
+                <input type="hidden" name="sff_selected_owner" id="sff_selected_owner" value="">
+
+                <div id="sff-ingredient-selection-note" style="display:none; margin-bottom:15px; padding:10px; background:#f2f9f3; border-radius:8px; font-size:0.95rem; color:#235d3a;"></div>
 
                 <?php
                 $show_category_dropdown = apply_filters('sff_show_category_dropdown', empty($fdc_id));
@@ -427,6 +564,8 @@ function sff_render_ingredient_meta_box($post) {
 function sff_save_ingredient_details($post_id) {
      if (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) return;
 
+    sff_assign_ingredient_owner($post_id);
+
     if (isset($_POST['sff_quantity'])) {
         update_post_meta($post_id, '_sff_quantity', sanitize_text_field($_POST['sff_quantity']));
     }
@@ -485,6 +624,14 @@ function sff_save_ingredient_details($post_id) {
         } else {
             $wpdb->insert($table, $data, $formats);
         }
+    }
+
+    if (isset($_POST['sff_source_ingredient'])) {
+        update_post_meta($post_id, '_sff_source_ingredient', intval($_POST['sff_source_ingredient']));
+    }
+
+    if (isset($_POST['sff_selected_owner'])) {
+        update_post_meta($post_id, '_sff_selected_owner', sanitize_text_field($_POST['sff_selected_owner']));
     }
 }
 add_action('save_post', 'sff_save_ingredient_details');


### PR DESCRIPTION
## Summary
- add helper utilities to persist ingredient ownership and prepare database payloads for the frontend
- expose AJAX endpoints and UI logic so clients can search shared and personal ingredient libraries with a label-scan fallback
- refresh ingredient form styles to support the new suggestion list and selection note

## Testing
- php -l wp-content/plugins/simplified-food-fitness/includes/helpers.php
- php -l wp-content/plugins/simplified-food-fitness/includes/ajax.php

------
https://chatgpt.com/codex/tasks/task_e_68e634315d288329836693bd86f51358